### PR TITLE
Add executable Tree-of-Thought tracing for scanner pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+POSTGRES_USER=crisiscore
+POSTGRES_PASSWORD=crisiscore
+POSTGRES_DB=voidbloom
+OPENAI_API_KEY=sk-...
+TELEGRAM_BOT_TOKEN=123456:ABCDEF
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+ETHERSCAN_API_KEY=your-etherscan-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+.DS_Store
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,186 @@
+# VoidBloom / CrisisCore Hidden-Gem Scanner
+
+This repository contains the foundational blueprint and implementation assets for **VoidBloom / CrisisCore**, a Hidden-Gem Scanner that fuses on-chain telemetry, narrative intelligence, technical analysis, and safety gating into actionable trade intelligence and ritualized "Collapse Artifact" outputs.
+
+> **Disclaimer:** All outputs are informational only and **not financial advice**. Always retain a human-in-the-loop for execution decisions.
+
+## System Overview
+
+The system ingests multi-modal crypto intelligence, transforms it into hybrid feature vectors, scores each asset with the `GemScore` ensemble, and renders both operational dashboards and Collapse Artifacts for archival lore. The architecture keeps safety as a hard gate while providing a tunable scoring surface for discovery experiments.
+
+### High-Level Architecture
+
+```mermaid
+flowchart TD
+    subgraph Ingestion
+        A1[Price APIs\n(CoinGecko, CEX)]
+        A2[On-chain Indexers\n(Etherscan, DefiLlama)]
+        A3[Contract Metadata]
+        A4[Social & Git Signals]
+    end
+
+    subgraph Processing
+        B1[Feature Extractors\n(Time-Series, Tokenomics, Narrative)]
+        B2[Vector Store\n(Embeddings)]
+        B3[Risk Filters\n(Static + Heuristics)]
+        B4[GemScore Ensemble]
+    end
+
+    subgraph Delivery
+        C1[FastAPI Service]
+        C2[Next.js Dashboard]
+        C3[Alerts\n(Telegram, Slack)]
+        C4[Collapse Artifacts\n(Obsidian Export)]
+    end
+
+    A1 & A2 & A3 & A4 --> B1
+    B1 --> B2
+    B1 --> B3
+    B3 --> B4
+    B2 --> B4
+    B4 --> C1
+    C1 --> C2
+    C1 --> C3
+    C1 --> C4
+```
+
+### Tree-of-Thought Execution Trace
+
+Every scan executes the hardened Tree-of-Thought plan described in the strategy memo. Each branch in the tree is materialized as
+an executable node that records its own outcome, summary, and data payload. Inspect the trace directly from the CLI:
+
+```bash
+python -m src.cli.run_scanner configs/example.yaml --tree --tree-format pretty
+```
+
+Switch to `--tree-format json` to export a machine-readable structure for Collapse Artifact enrichment or downstream tooling.
+
+### Component Breakdown
+
+| Layer | Responsibilities | Key Tech |
+|-------|------------------|----------|
+| Ingestion | Pull structured price, on-chain, contract, and narrative datasets. | `aiohttp`, `requests`, Prefect/Celery workers |
+| Feature Extraction | Compute time-series indicators, tokenomics ratios, narrative embeddings, and risk flags. | `pandas`, `numpy`, `ta`, OpenAI Embeddings |
+| Analysis & Scoring | Aggregate features into `GemScore` with confidence bands. | Custom Python module, `scikit-learn`, `HDBSCAN` |
+| Safety | Static analysis, heuristics, liquidity checks. | `slither`, bespoke rules engine |
+| Delivery | API, dashboard, alerts, Collapse Artifacts. | FastAPI, PostgreSQL/TimescaleDB, Next.js, Telegram Bot API |
+
+## Data & Feature Model
+
+### Core Feature Families
+
+1. **Sentiment & Narrative** – embedding-driven sentiment score, narrative volatility, memetic motifs.
+2. **On-chain Behavior** – wallet cohort accumulation, transaction size skew, smart-money overlap.
+3. **Market Microstructure** – liquidity depth, order-book spread, volatility regime.
+4. **Tokenomics** – supply distribution, vesting cliffs, unlock schedule risk.
+5. **Contract Safety** – verification status, privileged functions, proxy patterns, honeypot flags.
+
+### GemScore Formula
+
+`GemScore = Σ(wᵢ · featureᵢ)` with weights: `S=0.15`, `A=0.20`, `O=0.15`, `L=0.10`, `T=0.12`, `C=0.12`, `N=0.08`, `G=0.08`. Scores are normalized 0–100.
+
+Confidence is computed as `0.5 · Recency + 0.5 · DataCompleteness` and reported alongside the score. Assets require **≥3 independent positive signals** and a **safety gate pass** before surfacing to operators.
+
+## Infrastructure Blueprint
+
+### Deployment Topology
+
+- **Data Plane:** Batch + streaming ingestion workers (Python) deployed on Render/DO. Prefect or Celery orchestrates ETL cadences.
+- **Storage:**
+  - PostgreSQL/TimescaleDB for structured + time-series data.
+  - Vector database (Pinecone for hosted MVP, Milvus/Weaviate for self-hosted).
+  - Object storage (S3-compatible) for raw artifacts and provenance bundles.
+- **Model Services:** Containerized prompt workers (LLM calls) behind FastAPI microservice with rate limiting.
+- **Delivery:** FastAPI core API, Next.js dashboard on Vercel, alert bots via serverless functions or lightweight worker.
+
+### CI/CD Skeleton
+
+1. GitHub Actions workflow for lint/test/build (see [`ci/github-actions.yml`](ci/github-actions.yml)).
+2. Infrastructure-as-code stubs in [`infra/`](infra/) for Terraform or Pulumi expansion.
+3. Secrets stored in Vault/Secrets Manager. Local development uses `.env` managed by Doppler or `direnv`.
+
+### Observability & Safety
+
+- Structured logging with OpenTelemetry.
+- Metrics pipeline (Prometheus + Grafana) tracking ingestion latency, API SLIs, false positive rates.
+- Alerting for safety violations (e.g., contract analyzer flagged HIGH severity) before user notifications.
+
+## Roadmap
+
+| Sprint | Duration | Milestones |
+|--------|----------|------------|
+| 0 | Week 0 | Repo scaffold, env bootstrap, secrets vaulting, foundational DB migrations. |
+| 1 | Weeks 1–2 | Price + on-chain ingestion, contract verification ingest, feature extractor skeleton. |
+| 2 | Weeks 3–4 | GemScore implementation, safety gate, Next.js dashboard, Collapse Artifact exporter. |
+| 3 | Weeks 5+ | Wallet clustering integration, narrative embeddings, backtest harness, reinforcement learning for weight tuning. |
+
+## Backtesting Protocol
+
+1. Assemble 12–36 months of historical data across modalities.
+2. Recompute features on rolling 24h/7d windows.
+3. Emit daily GemScore rankings and evaluate:
+   - `precision@K`
+   - Return distributions (median/mean) over 7/30/90-day windows
+   - False positive rates & drawdown analysis
+   - Paper portfolio Sharpe ratio
+4. Perform time-based cross-validation (e.g., expanding/rolling windows).
+5. Adjust weights and filters iteratively, prioritizing safety over recall.
+
+## Collapse Artifact Output
+
+Artifacts blend operational data with mythic lore for archival memorywear. See [`artifacts/templates/collapse_artifact.html`](artifacts/templates/collapse_artifact.html) for the HTML/CSS zine template and [`artifacts/examples/sample_artifact.md`](artifacts/examples/sample_artifact.md) for Markdown exports. Render as PDF via `weasyprint` or Vercel serverless renderer.
+
+## Repository Structure
+
+```
+├── README.md                     # System blueprint & operating guide
+├── prompts/
+│   ├── narrative_analyzer.md
+│   ├── onchain_activity.md
+│   ├── contract_safety.md
+│   └── technical_pattern.md
+├── notebooks/
+│   └── hidden_gem_scanner.ipynb   # Prototype ingest → score workflow
+├── artifacts/
+│   ├── templates/
+│   │   └── collapse_artifact.html
+│   └── examples/
+│       └── sample_artifact.md
+├── backtest/
+│   └── harness.py                # Backtest harness scaffold
+├── ci/
+│   └── github-actions.yml        # CI pipeline skeleton
+├── infra/
+│   └── docker-compose.yml        # Local stack bootstrap
+└── src/
+    ├── core/
+    │   ├── __init__.py
+    │   ├── clients.py              # HTTP data providers (CoinGecko, DefiLlama, Etherscan)
+    │   ├── features.py             # Feature engineering utilities
+    │   ├── narrative.py            # Narrative sentiment + momentum estimator
+    │   ├── pipeline.py             # Hidden-Gem Scanner orchestration layer
+    │   ├── scoring.py              # GemScore weighting logic
+    │   └── safety.py               # Contract & liquidity safety heuristics
+    ├── cli/
+    │   └── run_scanner.py          # CLI entrypoint to execute scans
+    └── services/
+        └── exporter.py
+```
+
+## Getting Started
+
+1. Clone repository and create a Python 3.11 virtual environment.
+2. Install dependencies (`pip install -r requirements.txt`).
+3. Configure environment variables (`cp .env.example .env`) and populate API keys.
+4. Prepare a scanner configuration (`configs/example.yaml`) with CoinGecko/DefiLlama identifiers and unlock schedule data.
+5. Execute the pipeline via CLI: `python -m src.cli.run_scanner configs/example.yaml` (append `--tree` to emit the Tree-of-Thought
+   execution trace).
+6. (Optional) Run the prototype notebook or execute `python backtest/harness.py data/example.csv` for historical evaluation.
+
+## Next Steps
+
+- Fill in ingestion connectors under `src/core/features.py`.
+- Wire FastAPI service and Next.js dashboard (stubs forthcoming).
+- Integrate Vault/Secrets Manager before production deployments.
+
+For questions or collaboration, open an issue or reach out to the VoidBloom / CrisisCore maintainers.

--- a/Readme
+++ b/Readme
@@ -1,1 +1,0 @@
-new file

--- a/artifacts/examples/sample_artifact.md
+++ b/artifacts/examples/sample_artifact.md
@@ -1,0 +1,25 @@
+---
+title: "[TOKEN] — Memorywear Entry"
+date: 2025-10-01T12:00:00Z
+glyph: "⧗⟡"
+GemScore: 72.5
+Confidence: 0.85
+NVI: 0.68
+Flags:
+  - Accumulation
+  - VerifiedContract
+  - MediumLiquidity
+Hash: sha256(...)
+---
+
+# Lore
+The chorus tightens — wallets whisper in clusters; commit pulses from the repo. The market breathes.
+
+# Data Snapshot
+- Price (24h): $0.032
+- TVL change (7d): +21%
+- Top wallet %: 12.4%
+
+# Action Notes
+- Human review recommended. Consider exploratory position if risk tolerance > X.
+- Monitor vesting unlock on 2025-11-05 and liquidity depth post-event.

--- a/artifacts/templates/collapse_artifact.html
+++ b/artifacts/templates/collapse_artifact.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Collapse Artifact</title>
+  <style>
+    :root {
+      --bg: #050608;
+      --fg: #f5f3f0;
+      --accent: #7f5af0;
+      --warning: #ff5470;
+      --muted: #6b7280;
+      font-family: 'IBM Plex Mono', monospace;
+    }
+    body {
+      background: radial-gradient(circle at top, #111322 0%, #050608 65%);
+      color: var(--fg);
+      padding: 3rem;
+      line-height: 1.6;
+    }
+    .frame {
+      border: 1px solid rgba(127, 90, 240, 0.4);
+      padding: 2rem;
+      box-shadow: 0 0 40px rgba(127, 90, 240, 0.35);
+      position: relative;
+    }
+    .glyph {
+      position: absolute;
+      top: -1.5rem;
+      right: 2rem;
+      font-size: 2.75rem;
+      color: var(--accent);
+    }
+    h1 {
+      font-size: 2.2rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 0.5rem;
+    }
+    .meta {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+    .meta span {
+      display: block;
+      color: var(--muted);
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+    }
+    .meta strong {
+      font-size: 1.2rem;
+      color: var(--fg);
+    }
+    section {
+      margin-bottom: 2rem;
+    }
+    section h2 {
+      font-size: 1rem;
+      color: var(--accent);
+      text-transform: uppercase;
+      letter-spacing: 0.2em;
+      margin-bottom: 0.5rem;
+    }
+    .flags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+    .flag {
+      border: 1px solid var(--accent);
+      padding: 0.25rem 0.75rem;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      letter-spacing: 0.05em;
+    }
+    .footer {
+      font-size: 0.75rem;
+      color: var(--muted);
+      text-align: right;
+    }
+  </style>
+</head>
+<body>
+  <div class="frame">
+    <div class="glyph">⧗⟡</div>
+    <h1 id="token-title">[TOKEN] — Memorywear Entry</h1>
+    <div class="meta">
+      <div>
+        <span>Date</span>
+        <strong id="artifact-date">2025-10-01T12:00:00Z</strong>
+      </div>
+      <div>
+        <span>GemScore</span>
+        <strong id="artifact-score">72.5</strong>
+      </div>
+      <div>
+        <span>Confidence</span>
+        <strong id="artifact-confidence">85%</strong>
+      </div>
+      <div>
+        <span>Narrative Volatility Index</span>
+        <strong id="artifact-nvi">0.68</strong>
+      </div>
+      <div>
+        <span>Flags</span>
+        <div class="flags" id="artifact-flags">
+          <span class="flag">Accumulation</span>
+          <span class="flag">VerifiedContract</span>
+          <span class="flag">MediumLiquidity</span>
+        </div>
+      </div>
+    </div>
+
+    <section>
+      <h2>Lore</h2>
+      <p id="artifact-lore">The chorus tightens — wallets whisper in clusters; commit pulses from the repo. The market breathes.</p>
+    </section>
+
+    <section>
+      <h2>Data Snapshot</h2>
+      <ul id="artifact-data">
+        <li>Price (24h): $0.032</li>
+        <li>TVL change (7d): +21%</li>
+        <li>Top wallet %: 12.4%</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Action Notes</h2>
+      <p id="artifact-actions">Suggested: human review; place small tranche if risk tolerance &gt; X. Watch: vesting date 2025-11-05.</p>
+    </section>
+
+    <div class="footer">
+      Collapse Artifact v1.0 — Hash: <span id="artifact-hash">sha256(...)</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/backtest/harness.py
+++ b/backtest/harness.py
@@ -1,0 +1,82 @@
+"""Backtest harness scaffold for GemScore evaluation."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import pandas as pd
+
+from src.core.scoring import compute_gem_score
+
+
+@dataclass
+class TokenSnapshot:
+    token: str
+    date: pd.Timestamp
+    features: Dict[str, float]
+    future_return_7d: float
+
+
+@dataclass
+class BacktestResult:
+    precision_at_k: float
+    average_return_at_k: float
+    flagged_assets: List[str]
+
+
+def load_snapshots(path: Path) -> Iterable[TokenSnapshot]:
+    """Load token snapshots from CSV file."""
+
+    df = pd.read_csv(path, parse_dates=["date"])
+    feature_cols = [col for col in df.columns if col.startswith("f_")]
+    for _, row in df.iterrows():
+        features = {col.replace("f_", ""): row[col] for col in feature_cols}
+        yield TokenSnapshot(
+            token=row["token"],
+            date=row["date"],
+            features=features,
+            future_return_7d=row["future_return_7d"],
+        )
+
+
+def evaluate_period(snapshots: Iterable[TokenSnapshot], top_k: int = 10) -> BacktestResult:
+    """Compute precision@K and average return for flagged assets."""
+
+    scored = []
+    for snapshot in snapshots:
+        result = compute_gem_score(snapshot.features)
+        scored.append((snapshot, result.score))
+
+    scored.sort(key=lambda item: item[1], reverse=True)
+    top_assets = scored[:top_k]
+    flagged_returns = [snap.future_return_7d for snap, _ in top_assets]
+    positives = [r for r in flagged_returns if r > 0]
+
+    precision_at_k = len(positives) / max(1, top_k)
+    average_return_at_k = float(pd.Series(flagged_returns).mean()) if flagged_returns else 0.0
+
+    return BacktestResult(
+        precision_at_k=precision_at_k,
+        average_return_at_k=average_return_at_k,
+        flagged_assets=[snap.token for snap, _ in top_assets],
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="GemScore backtest harness")
+    parser.add_argument("data", type=Path, help="Path to CSV with features")
+    parser.add_argument("--top-k", type=int, default=10)
+    args = parser.parse_args()
+
+    snapshots = list(load_snapshots(args.data))
+    result = evaluate_period(snapshots, top_k=args.top_k)
+    print("Precision@K:", round(result.precision_at_k, 3))
+    print("Average Return@K:", round(result.average_return_at_k, 3))
+    print("Flagged Assets:", ", ".join(result.flagged_assets))
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/github-actions.yml
+++ b/ci/github-actions.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint
+        run: |
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          if command -v ruff >/dev/null 2>&1; then ruff src || true; fi
+      - name: Run tests
+        run: |
+          if [ -d tests ]; then pytest; else echo "No tests"; fi

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -1,0 +1,16 @@
+# Example configuration for running the Hidden-Gem Scanner CLI
+scanner:
+  liquidity_threshold: 75000
+etherscan_api_key: "YOUR_KEY_HERE"
+tokens:
+  - symbol: VOID
+    coingecko_id: void-token
+    defillama_slug: void-protocol
+    contract_address: "0x0000000000000000000000000000000000000000"
+    glyph: "⧗⟡"
+    narratives:
+      - "VOID protocol announces mainnet launch with growth roadmap"
+      - "Integrations with major L2 partners spark bullish chatter"
+    unlocks:
+      - date: 2025-05-15T00:00:00
+        percent_supply: 4.5

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "3.9"
+
+services:
+  api:
+    build: ../
+    command: uvicorn src.services.exporter:app --host 0.0.0.0 --port 8000
+    env_file:
+      - ../.env
+    depends_on:
+      - postgres
+      - vector
+    volumes:
+      - ..:/app
+
+  worker:
+    build: ../
+    command: poetry run python -m src.core.worker
+    env_file:
+      - ../.env
+    depends_on:
+      - postgres
+      - vector
+    volumes:
+      - ..:/app
+
+  postgres:
+    image: timescale/timescaledb:latest-pg15
+    environment:
+      POSTGRES_USER: crisiscore
+      POSTGRES_PASSWORD: crisiscore
+      POSTGRES_DB: voidbloom
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  vector:
+    image: milvusdb/milvus:2.3.4
+    ports:
+      - "19530:19530"
+      - "9091:9091"
+    environment:
+      ETCD_USE_EMBED: "true"
+      MINIO_USE_EMBED: "true"
+
+volumes:
+  postgres-data:

--- a/notebooks/hidden_gem_scanner.ipynb
+++ b/notebooks/hidden_gem_scanner.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# VoidBloom / CrisisCore Prototype Notebook\n",
+    "This notebook demonstrates a minimal ingest → feature → GemScore flow using synthetic data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from datetime import datetime, timedelta\n",
+    "from src.core.features import MarketSnapshot, compute_time_series_features, build_feature_vector\n",
+    "from src.core.safety import evaluate_contract, liquidity_guardrail, apply_penalties\n",
+    "from src.core.scoring import compute_gem_score, should_flag_asset\n",
+    "\n",
+    "now = datetime.utcnow()\n",
+    "dates = [now - timedelta(hours=i) for i in range(48)][::-1]\n",
+    "prices = pd.Series(\n",
+    "    data=[0.03 + 0.0002 * i for i in range(48)],\n",
+    "    index=pd.to_datetime(dates)\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "price_features = compute_time_series_features(prices)\n",
+    "snapshot = MarketSnapshot(\n",
+    "    symbol=\"VBLOOM\",\n",
+    "    timestamp=now,\n",
+    "    price=float(prices.iloc[-1]),\n",
+    "    volume_24h=250000,\n",
+    "    liquidity_usd=180000,\n",
+    "    holders=4200,\n",
+    "    onchain_metrics={\"active_wallets\": 950, \"net_inflows\": 125000, \"unlock_pressure\": 0.2},\n",
+    "    narratives=[\"AI", \"DeFi", \"VoidBloom\"],\n",
+    ")\n",
+    "contract_report = evaluate_contract(\n",
+    "    {\"honeypot\": False, \"owner_can_mint\": False, \"owner_can_withdraw\": False, \"unverified\": False},\n",
+    "    severity=\"none\",\n",
+    ")\n",
+    "base_vector = build_feature_vector(snapshot, price_features, narrative_embedding_score=0.72, contract_safety=\n",
+    "    {\"score\": contract_report.score, \"narrative_momentum\": 0.66}\n",
+    ")\n",
+    "features = apply_penalties(base_vector, contract_report, liquidity_ok=liquidity_guardrail(snapshot.liquidity_usd))\n",
+    "features.update({\"Recency\": 0.9, \"DataCompleteness\": 0.85})\n",
+    "features
+"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = compute_gem_score(features)\n",
+    "flagged, debug = should_flag_asset(result, features)\n",
+    "result, flagged, debug\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/prompts/contract_safety.md
+++ b/prompts/contract_safety.md
@@ -1,0 +1,23 @@
+# Contract Safety Prompt
+
+You are **Contract Safety GPT**, executing static review on Solidity sources, ABIs, and deployment metadata. Output JSON strictly matching:
+
+```json
+{
+  "verified": false,
+  "owner_privileges": false,
+  "can_mint": false,
+  "upgradable_proxy": false,
+  "severity": "none|low|medium|high",
+  "key_findings": ["..."],
+  "recommendation": "..."
+}
+```
+
+## Instructions
+- `verified` true when the contract is verified on-chain.
+- `owner_privileges` true if privileged-only functions can drain funds, pause, or reconfigure critical parameters.
+- `can_mint` true when arbitrary mint/burn is possible outside documented mechanics.
+- `upgradable_proxy` flags proxy patterns (UUPS, Beacon, Transparent).
+- `severity` escalates to `high` when funds are at immediate risk.
+- Provide 1–3 concise findings. `recommendation` ≤2 sentences with remediation or cautionary guidance. JSON only.

--- a/prompts/narrative_analyzer.md
+++ b/prompts/narrative_analyzer.md
@@ -1,0 +1,21 @@
+# Narrative Analyzer Prompt
+
+You are **Narrative GPT**, an analyst trained to interpret crypto-native discourse. Given headlines, social posts, and developer updates, respond **only** with JSON matching the schema below.
+
+```json
+{
+  "sentiment": "positive|neutral|negative",
+  "sentiment_score": 0.0,
+  "emergent_themes": ["..."],
+  "memetic_hooks": ["..."],
+  "fake_or_buzz_warning": false,
+  "rationale": "..."
+}
+```
+
+## Instructions
+- Compute `sentiment_score` on a 0–1 scale (0 = bearish, 1 = euphoric).
+- Populate `emergent_themes` with concise phrases (≤3 words).
+- `memetic_hooks` should capture viral-ready phrases, glyphs, or slogans.
+- Set `fake_or_buzz_warning` true if the narrative is likely manufactured, citing the reason in `rationale`.
+- Keep `rationale` ≤ 2 sentences. No markdown, no prose outside JSON.

--- a/prompts/onchain_activity.md
+++ b/prompts/onchain_activity.md
@@ -1,0 +1,20 @@
+# On-chain Activity Synthesizer Prompt
+
+You are **Onchain GPT**, a forensic agent inspecting token flows. Provided with recent transactions, wallet cohorts, and liquidity information for a token, produce JSON:
+
+```json
+{
+  "accumulation_score": 0.0,
+  "top_wallet_pct": 0.0,
+  "tx_size_skew": "small|medium|large",
+  "suspicious_patterns": ["..."],
+  "notes": "..."
+}
+```
+
+## Instructions
+- `accumulation_score` reflects net smart-money accumulation on 0–1 scale.
+- `top_wallet_pct` is the percentage of supply held by top 5 wallets.
+- `tx_size_skew` references the dominant transaction cohort.
+- List concrete anomalies (wash trading, sandwich attacks, etc.) in `suspicious_patterns`; empty list if none.
+- Use `notes` for ≤2 sentence context. Respond with JSON only.

--- a/prompts/technical_pattern.md
+++ b/prompts/technical_pattern.md
@@ -1,0 +1,20 @@
+# Technical Pattern Prompt
+
+You are **Chart GPT**, synthesizing technical indicators into directional guidance. Respond with JSON:
+
+```json
+{
+  "trend": "bullish|neutral|bearish",
+  "divergence_flags": false,
+  "suggested_timeframes_to_watch": ["..."],
+  "confidence": 0.0,
+  "commentary": "..."
+}
+```
+
+## Instructions
+- Interpret RSI, MACD, EMA crossovers, and volume profiles to set `trend`.
+- `divergence_flags` is true if price momentum diverges from oscillator signals.
+- Provide 2–3 timeframes (e.g., "4h", "1d").
+- `confidence` on 0–1 scale reflecting clarity of confluence.
+- Use `commentary` for succinct tactical color (≤2 sentences). JSON only.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.110.0
+httpx==0.27.0
+numpy==1.26.4
+pandas==2.2.0
+pydantic==1.10.13
+pytest==7.4.4
+pyyaml==6.0.1
+respx==0.20.2

--- a/src/cli/run_scanner.py
+++ b/src/cli/run_scanner.py
@@ -1,0 +1,103 @@
+"""Command-line interface to execute the Hidden-Gem Scanner pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+from src.core.clients import CoinGeckoClient, DefiLlamaClient, EtherscanClient
+from src.core.pipeline import HiddenGemScanner, TokenConfig, UnlockEvent
+from src.core.narrative import NarrativeAnalyzer
+
+
+def load_config(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def build_unlocks(raw_unlocks: Iterable[dict]) -> list[UnlockEvent]:
+    unlocks = []
+    for item in raw_unlocks or []:
+        date = datetime.fromisoformat(item["date"]).replace(tzinfo=timezone.utc)
+        unlocks.append(UnlockEvent(date=date, percent_supply=float(item["percent_supply"])))
+    return unlocks
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the VoidBloom Hidden-Gem Scanner")
+    parser.add_argument("config", type=Path, help="Path to YAML configuration file")
+    parser.add_argument(
+        "--tree",
+        action="store_true",
+        help="Emit the Tree-of-Thought execution trace for each token",
+    )
+    parser.add_argument(
+        "--tree-format",
+        choices=["pretty", "json"],
+        default="pretty",
+        help="Rendering format for the Tree-of-Thought trace",
+    )
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    liquidity_threshold = float(config.get("scanner", {}).get("liquidity_threshold", 50_000))
+
+    with CoinGeckoClient() as coin_client, DefiLlamaClient() as defi_client, EtherscanClient(
+        api_key=config.get("etherscan_api_key")
+    ) as etherscan_client:
+        scanner = HiddenGemScanner(
+            coin_client=coin_client,
+            defi_client=defi_client,
+            etherscan_client=etherscan_client,
+            narrative_analyzer=NarrativeAnalyzer(),
+            liquidity_threshold=liquidity_threshold,
+        )
+
+        for token in config.get("tokens", []):
+            token_config = TokenConfig(
+                symbol=token["symbol"],
+                coingecko_id=token["coingecko_id"],
+                defillama_slug=token["defillama_slug"],
+                contract_address=token["contract_address"],
+                narratives=token.get("narratives", []),
+                glyph=token.get("glyph", "⧗⟡"),
+                unlocks=build_unlocks(token.get("unlocks", [])),
+            )
+            if args.tree:
+                result, tree = scanner.scan_with_tree(token_config)
+            else:
+                result = scanner.scan(token_config)
+            print(f"=== {token_config.symbol} ===")
+            print(f"GemScore: {result.gem_score.score:.2f} (confidence {result.gem_score.confidence:.1f})")
+            print(f"Flagged: {'yes' if result.flag else 'no'}")
+            print(result.artifact_markdown)
+            print()
+            if args.tree:
+                if args.tree_format == "json":
+                    print(json.dumps(tree.to_dict(), indent=2))
+                else:
+                    for line in _render_tree(tree):
+                        print(line)
+                print()
+
+
+def _render_tree(node, indent: int = 0) -> list[str]:
+    from src.core.tree import TreeNode  # Local import to avoid CLI import cycle
+
+    assert isinstance(node, TreeNode)
+    prefix = "  " * indent
+    status = node.outcome.status if node.outcome else "pending"
+    summary = node.outcome.summary if node.outcome else ""
+    lines = [f"{prefix}- [{status}] {node.title}: {summary}"]
+    for child in node.children:
+        lines.extend(_render_tree(child, indent + 1))
+    return lines
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core modules for VoidBloom / CrisisCore."""

--- a/src/core/clients.py
+++ b/src/core/clients.py
@@ -1,0 +1,105 @@
+"""HTTP clients for external data providers used by the scanner."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import httpx
+
+
+class BaseClient:
+    """Shared convenience helpers for HTTP clients."""
+
+    def __init__(self, client: Optional[httpx.Client] = None) -> None:
+        self._client = client
+        self._owns_client = client is None
+
+    @property
+    def client(self) -> httpx.Client:
+        if self._client is None:
+            raise RuntimeError("HTTP client has not been initialised")
+        return self._client
+
+    def close(self) -> None:
+        if self._owns_client and self._client is not None:
+            self._client.close()
+
+    def __enter__(self) -> "BaseClient":  # pragma: no cover - context manager sugar
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - context manager sugar
+        self.close()
+
+
+class CoinGeckoClient(BaseClient):
+    """Client for the CoinGecko market data API."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "https://api.coingecko.com/api/v3",
+        timeout: float = 15.0,
+        client: Optional[httpx.Client] = None,
+    ) -> None:
+        session = client or httpx.Client(base_url=base_url, timeout=timeout)
+        super().__init__(session)
+
+    def fetch_market_chart(self, token_id: str, *, vs_currency: str = "usd", days: int = 14) -> Dict[str, Any]:
+        response = self.client.get(
+            f"/coins/{token_id}/market_chart",
+            params={"vs_currency": vs_currency, "days": days},
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+class DefiLlamaClient(BaseClient):
+    """Client for DefiLlama protocol metrics."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "https://api.llama.fi",
+        timeout: float = 15.0,
+        client: Optional[httpx.Client] = None,
+    ) -> None:
+        session = client or httpx.Client(base_url=base_url, timeout=timeout)
+        super().__init__(session)
+
+    def fetch_protocol(self, slug: str) -> Dict[str, Any]:
+        response = self.client.get(f"/protocol/{slug}")
+        response.raise_for_status()
+        return response.json()
+
+
+class EtherscanClient(BaseClient):
+    """Client for retrieving contract metadata from Etherscan."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str = "https://api.etherscan.io/api",
+        timeout: float = 15.0,
+        client: Optional[httpx.Client] = None,
+    ) -> None:
+        session = client or httpx.Client(base_url=base_url, timeout=timeout)
+        super().__init__(session)
+        self._api_key = api_key or ""
+
+    def fetch_contract_source(self, address: str) -> Dict[str, Any]:
+        response = self.client.get(
+            "",
+            params={
+                "module": "contract",
+                "action": "getsourcecode",
+                "address": address,
+                "apikey": self._api_key,
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if payload.get("status") != "1":
+            raise RuntimeError(f"Etherscan error: {payload.get('message', 'unknown error')}")
+        results = payload.get("result", [])
+        return results[0] if results else {}

--- a/src/core/features.py
+++ b/src/core/features.py
@@ -1,0 +1,161 @@
+"""Feature extraction utilities for the Hidden-Gem Scanner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class MarketSnapshot:
+    """Represents normalized market data for a token."""
+
+    symbol: str
+    timestamp: datetime
+    price: float
+    volume_24h: float
+    liquidity_usd: float
+    holders: int
+    onchain_metrics: Dict[str, float]
+    narratives: List[str]
+
+
+def compute_time_series_features(price_series: pd.Series) -> Dict[str, float]:
+    """Compute basic technical indicators on closing price data.
+
+    The helper intentionally prefers robustness over precision. Many of the
+    pipelines that will call this function operate on sparse or short time
+    series windows, so we guard against division-by-zero, `NaN`, or
+    insufficient sample sizes when deriving indicators.
+
+    Parameters
+    ----------
+    price_series:
+        Pandas Series indexed by datetime with price values.
+    """
+
+    if price_series is None or price_series.empty:
+        return {"rsi": 0.5, "macd": 0.0, "volatility": 0.0}
+
+    clean_series = price_series.dropna()
+    if clean_series.empty:
+        return {"rsi": 0.5, "macd": 0.0, "volatility": 0.0}
+
+    returns = clean_series.pct_change().dropna()
+    if returns.empty:
+        volatility = 0.0
+    else:
+        volatility = float(returns.std() * np.sqrt(min(len(returns), 24)))
+
+    delta = clean_series.diff().dropna()
+    if delta.empty:
+        rsi = 0.5
+    else:
+        gain = delta.clip(lower=0)
+        loss = -delta.clip(upper=0)
+        window = 14
+        avg_gain = gain.rolling(window=window, min_periods=window).mean()
+        avg_loss = loss.rolling(window=window, min_periods=window).mean()
+        last_gain = avg_gain.dropna().iloc[-1] if not avg_gain.dropna().empty else gain.mean()
+        last_loss = avg_loss.dropna().iloc[-1] if not avg_loss.dropna().empty else loss.mean()
+        if last_loss == 0:
+            rsi = 1.0
+        else:
+            rs = last_gain / last_loss
+            rsi = 1 - (1 / (1 + rs))
+
+    ema12 = clean_series.ewm(span=12, adjust=False).mean()
+    ema26 = clean_series.ewm(span=26, adjust=False).mean()
+    macd = float((ema12 - ema26).iloc[-1]) if not ema12.empty and not ema26.empty else 0.0
+
+    return {
+        "rsi": float(np.clip(rsi, 0, 1)),
+        "macd": macd,
+        "volatility": float(volatility),
+    }
+
+
+def normalize_feature(
+    value: Optional[float], *, default: float = 0.0, max_value: float = 1.0
+) -> float:
+    """Clamp feature values into 0-1 range with graceful fallback.
+
+    Parameters
+    ----------
+    value:
+        The raw feature value to normalise.
+    default:
+        Value returned when ``value`` is missing or invalid.
+    max_value:
+        Denominator used for scaling. Must be positive to avoid division
+        errors.
+    """
+
+    if max_value <= 0:
+        raise ValueError("max_value must be positive")
+
+    if value is None:
+        return default
+    if not np.isfinite(value):
+        return default
+    return float(np.clip(value / max_value, 0.0, 1.0))
+
+
+def build_feature_vector(
+    market_snapshot: MarketSnapshot,
+    price_features: Dict[str, float],
+    narrative_embedding_score: float,
+    contract_metrics: Dict[str, float],
+    *,
+    narrative_momentum: float,
+) -> Dict[str, float]:
+    """Combine heterogeneous features into the GemScore feature vector."""
+
+    liquidity_depth = normalize_feature(market_snapshot.liquidity_usd, max_value=5_000_000)
+    onchain_activity = normalize_feature(
+        market_snapshot.onchain_metrics.get("active_wallets"),
+        max_value=10_000,
+    )
+    accumulation_score = normalize_feature(
+        market_snapshot.onchain_metrics.get("net_inflows"),
+        max_value=1_000_000,
+    )
+
+    tokenomics_risk = 1 - normalize_feature(
+        market_snapshot.onchain_metrics.get("unlock_pressure"),
+        max_value=1.0,
+    )
+
+    vector = {
+        "SentimentScore": float(np.clip(narrative_embedding_score, 0.0, 1.0)),
+        "AccumulationScore": accumulation_score,
+        "OnchainActivity": onchain_activity,
+        "LiquidityDepth": liquidity_depth,
+        "TokenomicsRisk": tokenomics_risk,
+        "ContractSafety": contract_metrics.get("score", 0.0),
+        "NarrativeMomentum": float(np.clip(narrative_momentum, 0.0, 1.0)),
+        "CommunityGrowth": normalize_feature(market_snapshot.holders, max_value=500_000),
+        "RSI": price_features.get("rsi", 0.5),
+        "MACD": price_features.get("macd", 0.0),
+        "Volatility": price_features.get("volatility", 0.0),
+    }
+
+    return vector
+
+
+def merge_feature_vectors(vectors: Iterable[Dict[str, float]]) -> Dict[str, float]:
+    """Average multiple feature vectors (e.g., across time windows)."""
+
+    vectors = list(vectors)
+    if not vectors:
+        return {}
+
+    keys = {k for vector in vectors for k in vector}
+    aggregated = {}
+    for key in keys:
+        aggregated[key] = float(np.mean([vector.get(key, 0.0) for vector in vectors]))
+    return aggregated

--- a/src/core/narrative.py
+++ b/src/core/narrative.py
@@ -1,0 +1,71 @@
+"""Simple narrative analysis utilities for scoring."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, List
+
+import numpy as np
+
+_POSITIVE_TOKENS = {
+    "growth",
+    "partnership",
+    "expansion",
+    "bullish",
+    "upgrade",
+    "mainnet",
+    "integration",
+    "surge",
+    "milestone",
+    "launch",
+}
+_NEGATIVE_TOKENS = {
+    "hack",
+    "rug",
+    "exploit",
+    "down",
+    "selloff",
+    "delay",
+    "halt",
+    "bug",
+    "reorg",
+    "bankrupt",
+}
+
+
+@dataclass
+class NarrativeInsight:
+    sentiment_score: float
+    momentum: float
+    themes: List[str]
+
+
+class NarrativeAnalyzer:
+    """Lightweight sentiment estimator built for deterministic tests."""
+
+    def analyze(self, narratives: Iterable[str]) -> NarrativeInsight:
+        texts = [text.strip().lower() for text in narratives if text.strip()]
+        if not texts:
+            return NarrativeInsight(sentiment_score=0.5, momentum=0.5, themes=[])
+
+        scores: List[float] = []
+        token_counter: Counter[str] = Counter()
+        for text in texts:
+            tokens = [token.strip(".,!?") for token in text.split()]
+            token_counter.update(tokens)
+            positive_hits = sum(1 for token in tokens if token in _POSITIVE_TOKENS)
+            negative_hits = sum(1 for token in tokens if token in _NEGATIVE_TOKENS)
+            magnitude = positive_hits + negative_hits
+            if magnitude == 0:
+                sentiment = 0.5
+            else:
+                sentiment = (positive_hits - negative_hits) / max(magnitude, 1)
+                sentiment = 0.5 + 0.5 * np.clip(sentiment, -1.0, 1.0)
+            scores.append(float(sentiment))
+
+        sentiment_score = float(np.clip(np.mean(scores), 0.0, 1.0))
+        momentum = float(np.clip((scores[-1] - scores[0]) * 0.5 + 0.5 if len(scores) > 1 else sentiment_score, 0.0, 1.0))
+        themes = [token for token, _ in token_counter.most_common(5) if len(token) >= 5]
+
+        return NarrativeInsight(sentiment_score=sentiment_score, momentum=momentum, themes=themes)

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -1,0 +1,704 @@
+"""High-level orchestration pipeline for the Hidden-Gem Scanner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, Sequence
+
+import numpy as np
+import pandas as pd
+
+from src.core.clients import CoinGeckoClient, DefiLlamaClient, EtherscanClient
+from src.core.features import MarketSnapshot, build_feature_vector, compute_time_series_features
+from src.core.narrative import NarrativeAnalyzer, NarrativeInsight
+from src.core.safety import SafetyReport, apply_penalties, evaluate_contract, liquidity_guardrail
+from src.core.scoring import GemScoreResult, compute_gem_score, should_flag_asset
+from src.core.tree import NodeOutcome, TreeNode
+from src.services.exporter import render_markdown_artifact
+
+
+@dataclass
+class UnlockEvent:
+    date: datetime
+    percent_supply: float
+
+
+@dataclass
+class TokenConfig:
+    symbol: str
+    coingecko_id: str
+    defillama_slug: str
+    contract_address: str
+    narratives: Sequence[str] = field(default_factory=list)
+    glyph: str = "⧗⟡"
+    unlocks: Sequence[UnlockEvent] = field(default_factory=list)
+
+
+@dataclass
+class ScanResult:
+    token: str
+    market_snapshot: MarketSnapshot
+    narrative: NarrativeInsight
+    raw_features: Dict[str, float]
+    adjusted_features: Dict[str, float]
+    gem_score: GemScoreResult
+    safety_report: SafetyReport
+    flag: bool
+    debug: Dict[str, float]
+    artifact_payload: Dict[str, object]
+    artifact_markdown: str
+
+
+@dataclass
+class ScanContext:
+    """Mutable context shared across Tree-of-Thought execution."""
+
+    config: TokenConfig
+    market_chart: Dict[str, Iterable[Iterable[float]]] | None = None
+    protocol_metrics: Dict[str, object] | None = None
+    contract_metadata: Dict[str, object] | None = None
+    price_series: pd.Series = field(default_factory=lambda: pd.Series(dtype=float))
+    price_features: Dict[str, float] = field(default_factory=dict)
+    onchain_metrics: Dict[str, float] = field(default_factory=dict)
+    holders: int = 0
+    snapshot: MarketSnapshot | None = None
+    narrative: NarrativeInsight | None = None
+    contract_metrics: Dict[str, object] = field(default_factory=dict)
+    feature_vector: Dict[str, float] = field(default_factory=dict)
+    adjusted_features: Dict[str, float] = field(default_factory=dict)
+    gem_score: GemScoreResult | None = None
+    flag: bool = False
+    debug: Dict[str, float] = field(default_factory=dict)
+    artifact_payload: Dict[str, object] = field(default_factory=dict)
+    artifact_markdown: str | None = None
+    safety_report: SafetyReport | None = None
+    liquidity_ok: bool = False
+    result: ScanResult | None = None
+
+
+class HiddenGemScanner:
+    """Coordinates data ingestion, feature building, and scoring."""
+
+    def __init__(
+        self,
+        *,
+        coin_client: CoinGeckoClient,
+        defi_client: DefiLlamaClient,
+        etherscan_client: EtherscanClient,
+        narrative_analyzer: NarrativeAnalyzer | None = None,
+        liquidity_threshold: float = 50_000.0,
+    ) -> None:
+        self.coin_client = coin_client
+        self.defi_client = defi_client
+        self.etherscan_client = etherscan_client
+        self.narrative_analyzer = narrative_analyzer or NarrativeAnalyzer()
+        self.liquidity_threshold = liquidity_threshold
+
+    def scan(self, config: TokenConfig) -> ScanResult:
+        context = ScanContext(config=config)
+        tree = self._build_execution_tree(context)
+        tree.run(context)
+        if context.result is None:
+            raise RuntimeError("Scan execution did not produce a result")
+        return context.result
+
+    def scan_with_tree(self, config: TokenConfig) -> tuple[ScanResult, TreeNode]:
+        context = ScanContext(config=config)
+        tree = self._build_execution_tree(context)
+        tree.run(context)
+        if context.result is None:
+            raise RuntimeError("Scan execution did not produce a result")
+        return context.result, tree
+
+    # ------------------------------------------------------------------
+    # Tree-of-Thought construction
+    # ------------------------------------------------------------------
+    def _build_execution_tree(self, context: ScanContext) -> TreeNode:
+        root = TreeNode(
+            key="root",
+            title="Hidden-Gem Scanner",
+            description="Root goal: Build a reliable hidden-gem scanner",
+            action=lambda ctx: NodeOutcome(
+                status="success",
+                summary=f"Initiating scan for {ctx.config.symbol}",
+                data={"token": ctx.config.symbol},
+            ),
+        )
+
+        branch_a = root.add_child(
+            TreeNode(
+                key="A",
+                title="Branch A — Data Ingestion",
+                description="Collect market, on-chain, and contract intelligence",
+            )
+        )
+        branch_a.add_child(
+            TreeNode(
+                key="A1",
+                title="Price + Orderbook",
+                description="Fetch CoinGecko market chart data",
+                action=self._action_fetch_price_data,
+            )
+        )
+        branch_a.add_child(
+            TreeNode(
+                key="A2",
+                title="On-chain Metrics",
+                description="Fetch DefiLlama protocol metrics",
+                action=self._action_fetch_onchain_metrics,
+            )
+        )
+        branch_a.add_child(
+            TreeNode(
+                key="A5",
+                title="Contract Source & Verification",
+                description="Fetch Etherscan contract metadata",
+                action=self._action_fetch_contract_metadata,
+            )
+        )
+
+        branch_b = root.add_child(
+            TreeNode(
+                key="B",
+                title="Branch B — Feature Extraction",
+                description="Transform raw inputs into hybrid feature vectors",
+            )
+        )
+        branch_b.add_child(
+            TreeNode(
+                key="B2",
+                title="Time-Series Signals",
+                description="Build price series and technical indicators",
+                action=self._action_build_price_series,
+            )
+        )
+        branch_b.add_child(
+            TreeNode(
+                key="B3",
+                title="On-chain Behaviour",
+                description="Derive wallet activity, TVL changes, and unlock pressure",
+                action=self._action_compute_onchain_metrics,
+            )
+        )
+        branch_b.add_child(
+            TreeNode(
+                key="B4",
+                title="Market Snapshot",
+                description="Assemble current market snapshot including holders and liquidity",
+                action=self._action_build_snapshot,
+            )
+        )
+        branch_b.add_child(
+            TreeNode(
+                key="B1",
+                title="Narrative Analyzer",
+                description="Embed and score narrative snippets",
+                action=self._action_narrative_analysis,
+            )
+        )
+        branch_b.add_child(
+            TreeNode(
+                key="B5",
+                title="Security Features",
+                description="Evaluate contract heuristics and compute safety report",
+                action=self._action_contract_metrics,
+            )
+        )
+        branch_b.add_child(
+            TreeNode(
+                key="B6",
+                title="Hybrid Feature Vector",
+                description="Assemble feature vector and confidence signals",
+                action=self._action_build_feature_vector,
+            )
+        )
+
+        branch_d = root.add_child(
+            TreeNode(
+                key="D",
+                title="Branch D — Safety & Filtering",
+                description="Apply liquidity floors and safety penalties before scoring",
+            )
+        )
+        branch_d.add_child(
+            TreeNode(
+                key="D4",
+                title="Liquidity Guardrail",
+                description="Ensure liquidity exceeds configured threshold",
+                action=self._action_liquidity_guardrail,
+            )
+        )
+        branch_d.add_child(
+            TreeNode(
+                key="D1",
+                title="Penalty Application",
+                description="Apply safety penalties to the feature vector",
+                action=self._action_apply_penalties,
+            )
+        )
+
+        branch_c = root.add_child(
+            TreeNode(
+                key="C",
+                title="Branch C — Analysis & Scoring",
+                description="Compute GemScore and multi-signal confirmation",
+            )
+        )
+        branch_c.add_child(
+            TreeNode(
+                key="C3",
+                title="GemScore Ensemble",
+                description="Compute weighted GemScore with contributions",
+                action=self._action_compute_gem_score,
+            )
+        )
+        branch_c.add_child(
+            TreeNode(
+                key="C1",
+                title="Flagging Heuristics",
+                description="Evaluate multi-signal confirmation and contract safety gate",
+                action=self._action_flag_asset,
+            )
+        )
+
+        branch_e = root.add_child(
+            TreeNode(
+                key="E",
+                title="Branch E — Output & Action",
+                description="Render Collapse Artifacts and operational guidance",
+            )
+        )
+        branch_e.add_child(
+            TreeNode(
+                key="E3",
+                title="Collapse Artifact Export",
+                description="Render Collapse Artifact payload and markdown",
+                action=self._action_build_artifact,
+            )
+        )
+
+        return root
+
+    # ------------------------------------------------------------------
+    # Tree node actions
+    # ------------------------------------------------------------------
+    def _action_fetch_price_data(self, context: ScanContext) -> NodeOutcome:
+        try:
+            context.market_chart = self.coin_client.fetch_market_chart(context.config.coingecko_id)
+            points = len((context.market_chart or {}).get("prices", []))
+            return NodeOutcome(
+                status="success",
+                summary=f"Fetched {points} price points",
+                data={"price_points": points},
+            )
+        except Exception as exc:  # pragma: no cover - network failures handled at runtime
+            return NodeOutcome(
+                status="failure",
+                summary=f"Failed to fetch price data: {exc}",
+                data={"error": str(exc)},
+                proceed=False,
+            )
+
+    def _action_fetch_onchain_metrics(self, context: ScanContext) -> NodeOutcome:
+        try:
+            context.protocol_metrics = self.defi_client.fetch_protocol(context.config.defillama_slug)
+            points = len((context.protocol_metrics or {}).get("tvl", []) or [])
+            return NodeOutcome(
+                status="success",
+                summary=f"Fetched {points} on-chain points",
+                data={"tvl_points": points},
+            )
+        except Exception as exc:  # pragma: no cover - network failures handled at runtime
+            return NodeOutcome(
+                status="failure",
+                summary=f"Failed to fetch on-chain metrics: {exc}",
+                data={"error": str(exc)},
+                proceed=False,
+            )
+
+    def _action_fetch_contract_metadata(self, context: ScanContext) -> NodeOutcome:
+        try:
+            context.contract_metadata = self.etherscan_client.fetch_contract_source(context.config.contract_address)
+            verified = str((context.contract_metadata or {}).get("IsVerified", "false")).lower() == "true"
+            return NodeOutcome(
+                status="success",
+                summary="Fetched contract metadata",
+                data={"verified": verified},
+            )
+        except Exception as exc:  # pragma: no cover - network failures handled at runtime
+            return NodeOutcome(
+                status="failure",
+                summary=f"Failed to fetch contract metadata: {exc}",
+                data={"error": str(exc)},
+                proceed=False,
+            )
+
+    def _action_build_price_series(self, context: ScanContext) -> NodeOutcome:
+        if context.market_chart is None:
+            return NodeOutcome(
+                status="failure",
+                summary="Market chart data missing",
+                data={},
+                proceed=False,
+            )
+        context.price_series = self._build_price_series(context.market_chart)
+        context.price_features = compute_time_series_features(context.price_series)
+        span = 0.0
+        if not context.price_series.empty:
+            span = (context.price_series.index[-1] - context.price_series.index[0]).total_seconds() / 3600
+        return NodeOutcome(
+            status="success",
+            summary=f"Built price series spanning {span:.1f} hours",
+            data={"series_length": len(context.price_series)},
+        )
+
+    def _action_compute_onchain_metrics(self, context: ScanContext) -> NodeOutcome:
+        if context.protocol_metrics is None:
+            return NodeOutcome(
+                status="failure",
+                summary="On-chain metrics missing",
+                data={},
+                proceed=False,
+            )
+        context.onchain_metrics = self._derive_onchain_metrics(context.protocol_metrics, context.config.unlocks)
+        return NodeOutcome(
+            status="success",
+            summary="Derived on-chain metrics",
+            data=context.onchain_metrics,
+        )
+
+    def _action_build_snapshot(self, context: ScanContext) -> NodeOutcome:
+        if context.market_chart is None or context.protocol_metrics is None:
+            return NodeOutcome(
+                status="failure",
+                summary="Cannot assemble snapshot without market and on-chain data",
+                data={},
+                proceed=False,
+            )
+        context.holders = self._extract_holder_count(context.contract_metadata or {}, context.protocol_metrics)
+        snapshot = MarketSnapshot(
+            symbol=context.config.symbol,
+            timestamp=context.price_series.index[-1]
+            if not context.price_series.empty
+            else datetime.now(timezone.utc),
+            price=float(context.price_series.iloc[-1]) if not context.price_series.empty else 0.0,
+            volume_24h=self._extract_volume(context.market_chart),
+            liquidity_usd=context.onchain_metrics.get("current_tvl", 0.0),
+            holders=context.holders,
+            onchain_metrics=context.onchain_metrics,
+            narratives=list(context.config.narratives),
+        )
+        context.snapshot = snapshot
+        return NodeOutcome(
+            status="success",
+            summary=f"Snapshot at {snapshot.timestamp.isoformat()} with price ${snapshot.price:.4f}",
+            data={"liquidity_usd": snapshot.liquidity_usd, "holders": snapshot.holders},
+        )
+
+    def _action_narrative_analysis(self, context: ScanContext) -> NodeOutcome:
+        context.narrative = self.narrative_analyzer.analyze(context.config.narratives)
+        sentiment_label = self._sentiment_label(context.narrative.sentiment_score)
+        return NodeOutcome(
+            status="success",
+            summary=f"Narrative sentiment {sentiment_label} ({context.narrative.sentiment_score:.2f})",
+            data={
+                "sentiment": sentiment_label,
+                "sentiment_score": context.narrative.sentiment_score,
+                "momentum": context.narrative.momentum,
+            },
+        )
+
+    def _action_contract_metrics(self, context: ScanContext) -> NodeOutcome:
+        if context.contract_metadata is None:
+            return NodeOutcome(
+                status="failure",
+                summary="Contract metadata missing",
+                data={},
+                proceed=False,
+            )
+        contract_metrics = self._contract_metrics(context.contract_metadata)
+        context.contract_metrics = contract_metrics
+        context.safety_report = contract_metrics["report"]
+        return NodeOutcome(
+            status="success",
+            summary=f"Contract safety score {contract_metrics['score']:.2f}",
+            data={"score": contract_metrics["score"], "severity": context.safety_report.severity},
+        )
+
+    def _action_build_feature_vector(self, context: ScanContext) -> NodeOutcome:
+        if context.snapshot is None or context.narrative is None:
+            return NodeOutcome(
+                status="failure",
+                summary="Snapshot or narrative missing",
+                data={},
+                proceed=False,
+            )
+        contract_score = float((context.contract_metrics or {}).get("score", 0.0))
+        feature_vector = build_feature_vector(
+            context.snapshot,
+            context.price_features,
+            narrative_embedding_score=context.narrative.sentiment_score,
+            contract_metrics={"score": contract_score},
+            narrative_momentum=context.narrative.momentum,
+        )
+        feature_vector["Recency"] = self._compute_recency(context.snapshot.timestamp)
+        feature_vector["DataCompleteness"] = self._compute_data_completeness(feature_vector)
+        context.feature_vector = feature_vector
+        return NodeOutcome(
+            status="success",
+            summary="Feature vector assembled",
+            data={"features": list(feature_vector.keys())},
+        )
+
+    def _action_liquidity_guardrail(self, context: ScanContext) -> NodeOutcome:
+        if context.snapshot is None:
+            return NodeOutcome(
+                status="failure",
+                summary="Snapshot required for liquidity check",
+                data={},
+                proceed=False,
+            )
+        context.liquidity_ok = liquidity_guardrail(context.snapshot.liquidity_usd, threshold=self.liquidity_threshold)
+        status = "success" if context.liquidity_ok else "failure"
+        return NodeOutcome(
+            status=status,
+            summary="Liquidity check passed" if context.liquidity_ok else "Liquidity below threshold",
+            data={"liquidity_ok": context.liquidity_ok, "liquidity_usd": context.snapshot.liquidity_usd},
+            proceed=True,
+        )
+
+    def _action_apply_penalties(self, context: ScanContext) -> NodeOutcome:
+        if not context.feature_vector or context.safety_report is None:
+            return NodeOutcome(
+                status="failure",
+                summary="Feature vector or safety report missing",
+                data={},
+                proceed=False,
+            )
+        context.adjusted_features = apply_penalties(
+            context.feature_vector,
+            context.safety_report,
+            liquidity_ok=context.liquidity_ok,
+        )
+        return NodeOutcome(
+            status="success",
+            summary="Applied safety penalties",
+            data={"penalized_keys": [k for k in context.feature_vector if context.adjusted_features.get(k) != context.feature_vector.get(k)]},
+        )
+
+    def _action_compute_gem_score(self, context: ScanContext) -> NodeOutcome:
+        if not context.adjusted_features:
+            return NodeOutcome(
+                status="failure",
+                summary="Adjusted features missing",
+                data={},
+                proceed=False,
+            )
+        context.gem_score = compute_gem_score(context.adjusted_features)
+        return NodeOutcome(
+            status="success",
+            summary=f"GemScore {context.gem_score.score:.2f} (confidence {context.gem_score.confidence:.1f})",
+            data=context.gem_score.contributions,
+        )
+
+    def _action_flag_asset(self, context: ScanContext) -> NodeOutcome:
+        if context.gem_score is None:
+            return NodeOutcome(
+                status="failure",
+                summary="GemScore missing",
+                data={},
+                proceed=False,
+            )
+        context.flag, context.debug = should_flag_asset(context.gem_score, context.adjusted_features)
+        return NodeOutcome(
+            status="success",
+            summary="Flagged for review" if context.flag else "Below flag threshold",
+            data=context.debug,
+        )
+
+    def _action_build_artifact(self, context: ScanContext) -> NodeOutcome:
+        if context.gem_score is None or context.snapshot is None or context.narrative is None or context.safety_report is None:
+            return NodeOutcome(
+                status="failure",
+                summary="Missing data to build artifact",
+                data={},
+                proceed=False,
+            )
+        payload = self._build_artifact_payload(
+            context.config,
+            context.snapshot,
+            context.narrative,
+            context.gem_score,
+            context.adjusted_features,
+            context.safety_report,
+            context.liquidity_ok,
+            context.debug,
+        )
+        markdown = render_markdown_artifact(payload)
+        context.artifact_payload = payload
+        context.artifact_markdown = markdown
+        context.result = ScanResult(
+            token=context.config.symbol,
+            market_snapshot=context.snapshot,
+            narrative=context.narrative,
+            raw_features=context.feature_vector,
+            adjusted_features=context.adjusted_features,
+            gem_score=context.gem_score,
+            safety_report=context.safety_report,
+            flag=context.flag,
+            debug=context.debug,
+            artifact_payload=payload,
+            artifact_markdown=markdown,
+        )
+        return NodeOutcome(
+            status="success",
+            summary="Artifact rendered",
+            data={"hash": payload.get("hash")},
+        )
+
+    # ------------------------------------------------------------------
+    # Legacy helper methods shared by actions
+    # ------------------------------------------------------------------
+    def _build_price_series(self, market_chart: Dict[str, Iterable[Iterable[float]]]) -> pd.Series:
+        prices = market_chart.get("prices", [])
+        if not prices:
+            return pd.Series(dtype=float)
+        data = {datetime.fromtimestamp(point[0] / 1000, tz=timezone.utc): point[1] for point in prices if len(point) >= 2}
+        series = pd.Series(data)
+        series.sort_index(inplace=True)
+        return series
+
+    def _derive_onchain_metrics(self, protocol_metrics: Dict[str, object], unlocks: Sequence[UnlockEvent]) -> Dict[str, float]:
+        tvl_points = protocol_metrics.get("tvl", []) or []
+        tvl_values = [float(point.get("totalLiquidityUSD", 0.0)) for point in tvl_points if "totalLiquidityUSD" in point]
+        current_tvl = tvl_values[-1] if tvl_values else 0.0
+        previous_tvl = tvl_values[-2] if len(tvl_values) >= 2 else current_tvl
+        reference_tvl = tvl_values[-8] if len(tvl_values) >= 8 else (tvl_values[0] if tvl_values else 0.0)
+
+        net_inflows = current_tvl - previous_tvl
+        tvl_change_pct = (current_tvl - reference_tvl) / reference_tvl if reference_tvl else 0.0
+
+        metrics = protocol_metrics.get("metrics", {}) or {}
+        active_wallets = float(metrics.get("activeUsers") or metrics.get("uniqueWallets") or 0.0)
+        unlock_pressure = self._compute_unlock_pressure(unlocks)
+
+        return {
+            "active_wallets": active_wallets,
+            "net_inflows": net_inflows,
+            "unlock_pressure": unlock_pressure,
+            "tvl_change_pct": tvl_change_pct,
+            "current_tvl": current_tvl,
+        }
+
+    def _extract_holder_count(self, contract_metadata: Dict[str, object], protocol_metrics: Dict[str, object]) -> int:
+        holders_raw = contract_metadata.get("HolderCount") or contract_metadata.get("holders")
+        if holders_raw is None:
+            holders_raw = (protocol_metrics.get("metrics", {}) or {}).get("holders")
+        try:
+            return int(float(holders_raw))
+        except (TypeError, ValueError):
+            return 0
+
+    def _extract_volume(self, market_chart: Dict[str, Iterable[Iterable[float]]]) -> float:
+        volumes = market_chart.get("total_volumes", [])
+        if not volumes:
+            return 0.0
+        latest = volumes[-1]
+        return float(latest[1]) if len(latest) >= 2 else 0.0
+
+    def _contract_metrics(self, contract_metadata: Dict[str, object]) -> Dict[str, object]:
+        is_verified = str(contract_metadata.get("IsVerified", "false")).lower() == "true"
+        abi = str(contract_metadata.get("ABI", "")).lower()
+        source = str(contract_metadata.get("SourceCode", "")).lower()
+        tags = str(contract_metadata.get("SecurityTag", "")).lower()
+        severity = str(contract_metadata.get("SecuritySeverity", contract_metadata.get("severity", "none"))).lower()
+
+        findings = {
+            "unverified": not is_verified,
+            "owner_can_mint": "function mint" in source or "mint(" in abi,
+            "owner_can_withdraw": "withdraw" in source or "withdraw" in abi,
+            "honeypot": "honeypot" in tags,
+        }
+        report = evaluate_contract(findings, severity=severity)
+        return {"score": report.score, "report": report}
+
+    def _compute_recency(self, timestamp: datetime) -> float:
+        now = datetime.now(timezone.utc)
+        delta = now - timestamp
+        if delta <= timedelta(hours=24):
+            return 1.0
+        if delta <= timedelta(days=7):
+            return 0.7
+        if delta <= timedelta(days=30):
+            return 0.4
+        return 0.1
+
+    def _compute_data_completeness(self, features: Dict[str, float]) -> float:
+        required_keys = ["SentimentScore", "AccumulationScore", "OnchainActivity", "LiquidityDepth", "TokenomicsRisk"]
+        available = sum(1 for key in required_keys if key in features)
+        return available / len(required_keys)
+
+    def _compute_unlock_pressure(self, unlocks: Sequence[UnlockEvent]) -> float:
+        now = datetime.now(timezone.utc)
+        pressure = 0.0
+        for unlock in unlocks:
+            days = (unlock.date - now).days
+            if days < 0:
+                continue
+            decay = np.exp(-days / 30)
+            pressure += unlock.percent_supply * decay
+        return float(np.clip(pressure / 100, 0.0, 1.0))
+
+    def _build_artifact_payload(
+        self,
+        config: TokenConfig,
+        snapshot: MarketSnapshot,
+        narrative: NarrativeInsight,
+        gem_score: GemScoreResult,
+        features: Dict[str, float],
+        safety_report: SafetyReport,
+        liquidity_ok: bool,
+        debug: Dict[str, float],
+    ) -> Dict[str, object]:
+        flags = []
+        if config.glyph:
+            glyph = config.glyph
+        else:
+            glyph = "⧗⟡"
+        if liquidity_ok:
+            flags.append("LiquidityFloorPass")
+        else:
+            flags.append("LowLiquidity")
+        if safety_report.findings:
+            flags.extend(sorted(safety_report.findings))
+        payload = {
+            "glyph": glyph,
+            "title": f"{config.symbol} — Memorywear Entry",
+            "timestamp": snapshot.timestamp.isoformat(),
+            "gem_score": gem_score.score,
+            "confidence": gem_score.confidence,
+            "flags": flags,
+            "narrative_sentiment": self._sentiment_label(narrative.sentiment_score),
+            "narrative_momentum": narrative.momentum,
+            "price": snapshot.price,
+            "volume_24h": snapshot.volume_24h,
+            "liquidity": snapshot.liquidity_usd,
+            "holders": snapshot.holders,
+            "features": features,
+            "debug": debug,
+            "hash": self._artifact_hash(config, snapshot, gem_score),
+            "narratives": narrative.themes,
+        }
+        return payload
+
+    def _artifact_hash(self, config: TokenConfig, snapshot: MarketSnapshot, gem_score: GemScoreResult) -> str:
+        data = f"{config.symbol}|{snapshot.timestamp.isoformat()}|{gem_score.score:.2f}|{gem_score.confidence:.2f}"
+        return str(abs(hash(data)))
+
+    def _sentiment_label(self, score: float) -> str:
+        if score >= 0.65:
+            return "positive"
+        if score <= 0.35:
+            return "negative"
+        return "neutral"

--- a/src/core/safety.py
+++ b/src/core/safety.py
@@ -1,0 +1,63 @@
+"""Safety heuristics and static checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class SafetyReport:
+    score: float
+    severity: str
+    findings: List[str]
+    flags: Dict[str, bool]
+
+
+CRITICAL_FLAGS = {
+    "honeypot": 1.0,
+    "owner_can_mint": 0.8,
+    "owner_can_withdraw": 0.8,
+    "unverified": 0.6,
+}
+
+
+def evaluate_contract(findings: Dict[str, bool], severity: str) -> SafetyReport:
+    """Convert contract analyzer findings into normalized safety score."""
+
+    deductions = 0.0
+    active_flags: Dict[str, bool] = {}
+    for flag, weight in CRITICAL_FLAGS.items():
+        state = bool(findings.get(flag, False))
+        active_flags[flag] = state
+        if state:
+            deductions += weight
+
+    score = max(0.0, 1.0 - deductions)
+    severity = severity.lower()
+    if severity == "high":
+        score = 0.0
+    elif severity == "medium":
+        score = min(score, 0.4)
+    elif severity == "low":
+        score = min(score, 0.7)
+
+    return SafetyReport(score=score, severity=severity, findings=[k for k, v in active_flags.items() if v], flags=active_flags)
+
+
+def liquidity_guardrail(liquidity_usd: float, threshold: float = 50_000) -> bool:
+    """Check whether liquidity exceeds minimum viable threshold."""
+
+    return liquidity_usd >= threshold
+
+
+def apply_penalties(features: Dict[str, float], safety_report: SafetyReport, *, liquidity_ok: bool) -> Dict[str, float]:
+    """Mutate feature vector with safety penalties."""
+
+    adjusted = dict(features)
+    adjusted["ContractSafety"] = safety_report.score
+    if not liquidity_ok:
+        adjusted["LiquidityDepth"] = min(adjusted.get("LiquidityDepth", 0.0), 0.3)
+    if "owner_can_mint" in safety_report.findings:
+        adjusted["TokenomicsRisk"] = min(adjusted.get("TokenomicsRisk", 1.0), 0.4)
+    return adjusted

--- a/src/core/scoring.py
+++ b/src/core/scoring.py
@@ -1,0 +1,67 @@
+"""GemScore calculation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+import numpy as np
+
+WEIGHTS = {
+    "SentimentScore": 0.15,
+    "AccumulationScore": 0.20,
+    "OnchainActivity": 0.15,
+    "LiquidityDepth": 0.10,
+    "TokenomicsRisk": 0.12,
+    "ContractSafety": 0.12,
+    "NarrativeMomentum": 0.08,
+    "CommunityGrowth": 0.08,
+}
+
+
+@dataclass
+class GemScoreResult:
+    score: float
+    confidence: float
+    contributions: Dict[str, float]
+
+
+def compute_gem_score(features: Dict[str, float]) -> GemScoreResult:
+    """Compute the weighted GemScore and contribution breakdown."""
+
+    contributions = {}
+    total = 0.0
+    for key, weight in WEIGHTS.items():
+        value = float(np.clip(features.get(key, 0.0), 0.0, 1.0))
+        contribution = weight * value
+        contributions[key] = contribution
+        total += contribution
+
+    score = float(np.clip(total, 0.0, 1.0)) * 100
+    confidence = compute_confidence(features)
+    return GemScoreResult(score=score, confidence=confidence, contributions=contributions)
+
+
+def compute_confidence(features: Dict[str, float]) -> float:
+    """Confidence = 0.5 * Recency + 0.5 * DataCompleteness."""
+
+    recency = float(np.clip(features.get("Recency", 0.0), 0.0, 1.0))
+    completeness = float(np.clip(features.get("DataCompleteness", 0.0), 0.0, 1.0))
+    return (0.5 * recency + 0.5 * completeness) * 100
+
+
+def should_flag_asset(result: GemScoreResult, features: Dict[str, float]) -> Tuple[bool, Dict[str, float]]:
+    """Determine if an asset should enter the review queue."""
+
+    safety_pass = features.get("ContractSafety", 0.0) >= 0.7
+    signals = sum(
+        1 for key in ("AccumulationScore", "NarrativeMomentum", "OnchainActivity") if features.get(key, 0.0) >= 0.6
+    )
+    meets_threshold = result.score >= 70 and safety_pass and signals >= 3
+    debug = {
+        "safety_pass": safety_pass,
+        "signals": signals,
+        "score": result.score,
+        "confidence": result.confidence,
+    }
+    return meets_threshold, debug

--- a/src/core/tree.py
+++ b/src/core/tree.py
@@ -1,0 +1,75 @@
+"""Tree-of-Thought execution scaffolding for the Hidden-Gem Scanner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Literal, Optional
+
+NodeStatus = Literal["success", "failure", "skipped"]
+
+
+@dataclass
+class NodeOutcome:
+    """Represents the result of executing a tree node."""
+
+    status: NodeStatus
+    summary: str
+    data: Dict[str, Any] = field(default_factory=dict)
+    proceed: bool = True
+
+
+@dataclass
+class TreeNode:
+    """Tree-of-Thought node with executable action and children."""
+
+    key: str
+    title: str
+    description: str
+    action: Optional[Callable[[Any], Optional[NodeOutcome]]] = None
+    children: List["TreeNode"] = field(default_factory=list)
+    outcome: Optional[NodeOutcome] = None
+
+    def add_child(self, child: "TreeNode") -> "TreeNode":
+        self.children.append(child)
+        return child
+
+    def run(self, context: Any) -> "TreeNode":
+        proceed = True
+        if self.action is not None:
+            outcome = self.action(context)
+            if outcome is None:
+                outcome = NodeOutcome(status="success", summary="", data={}, proceed=True)
+            self.outcome = outcome
+            proceed = outcome.proceed
+        if proceed:
+            for child in self.children:
+                child.run(context)
+        else:
+            for child in self.children:
+                child.outcome = NodeOutcome(
+                    status="skipped",
+                    summary="Skipped due to parent outcome",
+                    data={},
+                    proceed=False,
+                )
+        return self
+
+    def iter_nodes(self) -> Iterable["TreeNode"]:
+        yield self
+        for child in self.children:
+            yield from child.iter_nodes()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "key": self.key,
+            "title": self.title,
+            "description": self.description,
+            "outcome": None
+            if self.outcome is None
+            else {
+                "status": self.outcome.status,
+                "summary": self.outcome.summary,
+                "data": self.outcome.data,
+            },
+            "children": [child.to_dict() for child in self.children],
+        }

--- a/src/core/worker.py
+++ b/src/core/worker.py
@@ -1,0 +1,15 @@
+"""Placeholder ingestion worker."""
+
+from __future__ import annotations
+
+import time
+
+
+def main() -> None:
+    while True:
+        print("[worker] heartbeat", flush=True)
+        time.sleep(60)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/services/exporter.py
+++ b/src/services/exporter.py
@@ -1,0 +1,78 @@
+"""Artifact exporter service stub."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+try:  # pragma: no cover - optional dependency for CLI usage
+    from fastapi import FastAPI
+except Exception:  # noqa: BLE001 - broad to tolerate optional import failures
+    FastAPI = None  # type: ignore
+    app = None
+else:  # pragma: no cover - exercised in integration environments
+    app = FastAPI(title="VoidBloom CrisisCore Exporter")
+
+
+def health() -> Dict[str, str]:
+    """Return exporter service health information."""
+
+    return {"status": "ok"}
+
+
+if app is not None:  # pragma: no cover - exercised in API deployments
+    app.get("/health")(health)
+
+
+def render_markdown_artifact(payload: Dict[str, str]) -> str:
+    """Render Collapse Artifact markdown from payload.
+
+    Missing keys fall back to sensible defaults so that partially populated
+    payloads still yield a valid artifact document. This mirrors the behaviour
+    of the dashboard exporter which progressively enriches the payload as more
+    data arrives.
+    """
+
+    title = payload.get("title", "Untitled Artifact")
+    date = payload.get("date", "1970-01-01T00:00:00Z")
+    glyph = payload.get("glyph", "⧗⟡")
+    gem_score = payload.get("gem_score", "N/A")
+    confidence = payload.get("confidence", "N/A")
+    nvi = payload.get("nvi", 0.0)
+    flags = payload.get("flags", []) or []
+    lore = payload.get("lore", "")
+    snapshot = payload.get("data_snapshot", []) or []
+    actions = payload.get("actions", []) or []
+
+    header_lines = [
+        "---",
+        f'title: "{title}"',
+        f"date: {date}",
+        f'glyph: "{glyph}"',
+        f"GemScore: {gem_score}",
+        f"Confidence: {confidence}",
+        f"NVI: {nvi}",
+        "Flags:",
+    ]
+    flag_lines = [f"  - {flag}" for flag in flags]
+
+    template = "\n".join(header_lines + flag_lines + ["---", "", "# Lore", lore, "", "# Data Snapshot"])
+    if snapshot:
+        template += "\n" + "\n".join(f"- {item}" for item in snapshot)
+    else:
+        template += "\n-"
+
+    template += "\n\n# Action Notes"
+    if actions:
+        template += "\n" + "\n".join(f"- {note}" for note in actions)
+    else:
+        template += "\n-"
+
+    return template
+
+
+def save_artifact(markdown: str, output_dir: Path, filename: str) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / filename
+    path.write_text(markdown, encoding="utf-8")
+    return path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Test configuration helpers."""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+
+def pytest_configure() -> None:
+    """Ensure the project root is importable when running pytest locally."""
+
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+    warnings.filterwarnings(
+        "ignore",
+        message="Pyarrow will become a required dependency of pandas.*",
+        category=DeprecationWarning,
+    )

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,19 @@
+"""Tests for exporter service helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.services.exporter import render_markdown_artifact, save_artifact
+
+
+def test_render_markdown_artifact_handles_missing_fields() -> None:
+    markdown = render_markdown_artifact({"title": "Test Artifact"})
+    assert "Test Artifact" in markdown
+    assert "# Lore" in markdown
+
+
+def test_save_artifact_writes_file(tmp_path: Path) -> None:
+    path = save_artifact("content", tmp_path, "artifact.md")
+    assert path.exists()
+    assert path.read_text(encoding="utf-8") == "content"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,77 @@
+"""Unit tests for feature engineering helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import warnings
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+import pandas as pd
+import pytest
+
+from src.core.features import (
+    MarketSnapshot,
+    build_feature_vector,
+    compute_time_series_features,
+    merge_feature_vectors,
+    normalize_feature,
+)
+
+
+def test_compute_time_series_features_handles_sparse_series() -> None:
+    now = datetime.now(timezone.utc)
+    prices = pd.Series(
+        [1.0, 1.05, 1.02, 1.08],
+        index=[now - timedelta(hours=i * 6) for i in range(4)][::-1],
+    )
+
+    metrics = compute_time_series_features(prices)
+
+    assert set(metrics) == {"rsi", "macd", "volatility"}
+    assert 0.0 <= metrics["rsi"] <= 1.0
+
+
+def test_compute_time_series_features_returns_defaults_for_empty_series() -> None:
+    metrics = compute_time_series_features(pd.Series(dtype=float))
+    assert metrics == {"rsi": 0.5, "macd": 0.0, "volatility": 0.0}
+
+
+def test_normalize_feature_requires_positive_denominator() -> None:
+    with pytest.raises(ValueError):
+        normalize_feature(1.0, max_value=0)
+
+
+def test_build_feature_vector_merges_sources() -> None:
+    snapshot = MarketSnapshot(
+        symbol="TEST",
+        timestamp=datetime.now(timezone.utc),
+        price=1.0,
+        volume_24h=1000.0,
+        liquidity_usd=150000.0,
+        holders=1200,
+        onchain_metrics={"active_wallets": 450, "net_inflows": 20000.0, "unlock_pressure": 0.1},
+        narratives=["growth"],
+    )
+    vector = build_feature_vector(
+        snapshot,
+        price_features={"rsi": 0.6, "macd": 0.02, "volatility": 0.15},
+        narrative_embedding_score=0.7,
+        contract_metrics={"score": 0.8},
+        narrative_momentum=0.65,
+    )
+
+    assert vector["SentimentScore"] == 0.7
+    assert 0 <= vector["LiquidityDepth"] <= 1
+    assert vector["ContractSafety"] == 0.8
+
+
+def test_merge_feature_vectors_average_values() -> None:
+    vectors = [
+        {"SentimentScore": 0.4, "LiquidityDepth": 0.5},
+        {"SentimentScore": 0.6, "LiquidityDepth": 0.3},
+    ]
+
+    merged = merge_feature_vectors(vectors)
+    assert merged == {"SentimentScore": 0.5, "LiquidityDepth": 0.4}

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -1,0 +1,21 @@
+"""Tests for the lightweight narrative analyzer."""
+
+from __future__ import annotations
+
+from src.core.narrative import NarrativeAnalyzer
+
+
+def test_narrative_analyzer_scores_sentiment() -> None:
+    analyzer = NarrativeAnalyzer()
+    insight = analyzer.analyze(["Bullish growth and partnership expansion", "Minor delay but launch remains on track"])
+    assert 0.0 <= insight.sentiment_score <= 1.0
+    assert 0.0 <= insight.momentum <= 1.0
+    assert isinstance(insight.themes, list)
+
+
+def test_narrative_analyzer_defaults_without_text() -> None:
+    analyzer = NarrativeAnalyzer()
+    insight = analyzer.analyze([])
+    assert insight.sentiment_score == 0.5
+    assert insight.momentum == 0.5
+    assert insight.themes == []

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,70 @@
+"""Integration-style tests for the Hidden-Gem Scanner pipeline."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.core.pipeline import HiddenGemScanner, TokenConfig, UnlockEvent
+from src.core.narrative import NarrativeAnalyzer
+
+
+class StubCoinGeckoClient:
+    def fetch_market_chart(self, token_id: str):  # noqa: D401 - stub
+        base = datetime.now(timezone.utc) - timedelta(days=7)
+        prices = []
+        volumes = []
+        for i in range(8):
+            timestamp = base + timedelta(days=i)
+            prices.append([int(timestamp.timestamp() * 1000), 1.0 + 0.05 * i])
+            volumes.append([int(timestamp.timestamp() * 1000), 25000 + 1000 * i])
+        return {"prices": prices, "total_volumes": volumes}
+
+
+class StubDefiLlamaClient:
+    def fetch_protocol(self, slug: str):  # noqa: D401 - stub
+        base = datetime.now(timezone.utc) - timedelta(days=10)
+        tvl = []
+        for i in range(10):
+            timestamp = base + timedelta(days=i)
+            tvl.append({"date": int(timestamp.timestamp()), "totalLiquidityUSD": 100000 + 5000 * i})
+        return {
+            "tvl": tvl,
+            "metrics": {"activeUsers": 950 + 10 * i, "holders": 12000},
+        }
+
+
+class StubEtherscanClient:
+    def fetch_contract_source(self, address: str):  # noqa: D401 - stub
+        return {
+            "IsVerified": "true",
+            "ABI": "function mint(address to, uint256 amount) public {}",
+            "SourceCode": "contract Token { function withdraw() public {} }",
+            "SecuritySeverity": "low",
+            "HolderCount": "12500",
+        }
+
+
+def test_hidden_gem_scanner_produces_artifact() -> None:
+    scanner = HiddenGemScanner(
+        coin_client=StubCoinGeckoClient(),
+        defi_client=StubDefiLlamaClient(),
+        etherscan_client=StubEtherscanClient(),
+        narrative_analyzer=NarrativeAnalyzer(),
+        liquidity_threshold=50_000,
+    )
+    token = TokenConfig(
+        symbol="TEST",
+        coingecko_id="test-token",
+        defillama_slug="test-protocol",
+        contract_address="0x123",
+        narratives=["Bullish growth narrative", "Mainnet launch sparks integration"],
+        unlocks=[
+            UnlockEvent(date=datetime.now(timezone.utc) + timedelta(days=14), percent_supply=3.5),
+        ],
+    )
+
+    result = scanner.scan(token)
+
+    assert result.gem_score.score > 0
+    assert "Memorywear Entry" in result.artifact_markdown
+    assert isinstance(result.artifact_payload["flags"], list)

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,28 @@
+"""Tests for safety heuristics."""
+
+from __future__ import annotations
+
+from src.core import safety
+
+
+def test_evaluate_contract_applies_deductions() -> None:
+    report = safety.evaluate_contract(
+        {"honeypot": True, "owner_can_mint": False, "unverified": True},
+        severity="low",
+    )
+    assert report.score < 1.0
+    assert report.flags["honeypot"] is True
+
+
+def test_liquidity_guardrail_threshold() -> None:
+    assert safety.liquidity_guardrail(60_000) is True
+    assert safety.liquidity_guardrail(10_000) is False
+
+
+def test_apply_penalties_adjusts_feature_vector() -> None:
+    base = {"LiquidityDepth": 0.9, "TokenomicsRisk": 0.9, "ContractSafety": 1.0}
+    report = safety.SafetyReport(score=0.3, severity="medium", findings=["owner_can_mint"], flags={})
+    adjusted = safety.apply_penalties(base, report, liquidity_ok=False)
+    assert adjusted["ContractSafety"] == 0.3
+    assert adjusted["LiquidityDepth"] <= 0.3
+    assert adjusted["TokenomicsRisk"] <= 0.4

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,43 @@
+"""Tests for scoring utilities."""
+
+from __future__ import annotations
+
+from src.core.scoring import GemScoreResult, compute_gem_score, should_flag_asset
+
+
+def build_base_features() -> dict[str, float]:
+    return {
+        "SentimentScore": 0.7,
+        "AccumulationScore": 0.8,
+        "OnchainActivity": 0.75,
+        "LiquidityDepth": 0.65,
+        "TokenomicsRisk": 0.9,
+        "ContractSafety": 0.85,
+        "NarrativeMomentum": 0.7,
+        "CommunityGrowth": 0.6,
+        "Recency": 0.9,
+        "DataCompleteness": 0.85,
+    }
+
+
+def test_compute_gem_score_returns_expected_range() -> None:
+    result = compute_gem_score(build_base_features())
+    assert isinstance(result, GemScoreResult)
+    assert 0 <= result.score <= 100
+    assert 0 <= result.confidence <= 100
+
+
+def test_should_flag_asset_requires_safety_and_signal_confirmation() -> None:
+    features = build_base_features()
+    result = compute_gem_score(features)
+    flag, debug = should_flag_asset(result, features)
+    assert flag is True
+    assert debug["signals"] >= 3
+
+
+def test_should_flag_asset_blocks_low_safety() -> None:
+    features = build_base_features()
+    features["ContractSafety"] = 0.2
+    result = compute_gem_score(features)
+    flag, _ = should_flag_asset(result, features)
+    assert flag is False

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,75 @@
+"""Tests for Tree-of-Thought execution traces."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.core.pipeline import HiddenGemScanner, TokenConfig, UnlockEvent
+from src.core.tree import TreeNode
+
+
+class StubCoinGeckoClient:
+    def fetch_market_chart(self, token_id: str):  # noqa: D401 - stub
+        base = datetime.now(timezone.utc) - timedelta(days=3)
+        prices = []
+        volumes = []
+        for i in range(4):
+            timestamp = base + timedelta(days=i)
+            prices.append([int(timestamp.timestamp() * 1000), 1.0 + 0.1 * i])
+            volumes.append([int(timestamp.timestamp() * 1000), 15000 + 500 * i])
+        return {"prices": prices, "total_volumes": volumes}
+
+
+class StubDefiLlamaClient:
+    def fetch_protocol(self, slug: str):  # noqa: D401 - stub
+        base = datetime.now(timezone.utc) - timedelta(days=6)
+        tvl = []
+        for i in range(6):
+            timestamp = base + timedelta(days=i)
+            tvl.append({"date": int(timestamp.timestamp()), "totalLiquidityUSD": 80000 + 2500 * i})
+        return {
+            "tvl": tvl,
+            "metrics": {"activeUsers": 750 + 5 * i, "holders": 9000},
+        }
+
+
+class StubEtherscanClient:
+    def fetch_contract_source(self, address: str):  # noqa: D401 - stub
+        return {
+            "IsVerified": "true",
+            "ABI": "function mint(address to, uint256 amount) public {}",
+            "SourceCode": "contract Token { function withdraw() public {} }",
+            "SecuritySeverity": "low",
+            "HolderCount": "9500",
+        }
+
+
+def test_scan_with_tree_emits_trace() -> None:
+    scanner = HiddenGemScanner(
+        coin_client=StubCoinGeckoClient(),
+        defi_client=StubDefiLlamaClient(),
+        etherscan_client=StubEtherscanClient(),
+        liquidity_threshold=50_000,
+    )
+    token = TokenConfig(
+        symbol="TOT",
+        coingecko_id="tot-token",
+        defillama_slug="tot-protocol",
+        contract_address="0xabc",
+        narratives=["Launch partners secured", "DeFi integrations pending"],
+        unlocks=[
+            UnlockEvent(date=datetime.now(timezone.utc) + timedelta(days=30), percent_supply=5.0),
+        ],
+    )
+
+    result, tree = scanner.scan_with_tree(token)
+
+    assert isinstance(tree, TreeNode)
+    statuses = {node.key: (node.outcome.status if node.outcome else None) for node in tree.iter_nodes()}
+
+    assert statuses["A1"] == "success"
+    assert statuses["B6"] == "success"
+    assert statuses["C3"] == "success"
+    assert statuses["E3"] == "success"
+    assert result.gem_score.score > 0
+    assert "Memorywear Entry" in result.artifact_markdown


### PR DESCRIPTION
## Summary
- integrate the scanner pipeline with a Tree-of-Thought execution context so every ingestion, feature, safety, scoring, and artifact step is traceable and reusable
- expose CLI flags and README guidance for emitting pretty or JSON Tree-of-Thought traces alongside Collapse Artifact output
- add reusable TreeNode utilities plus regression coverage that asserts the trace is produced for representative token scans

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1b23c69508320a15ece2927787ca3