### PR TITLE
Add RSS news aggregation to scanner artifacts

### DIFF
--- a/docs/spec_alignment_review.md
+++ b/docs/spec_alignment_review.md
@@ -1,0 +1,48 @@
+# VoidBloom Data Oracle v1 – Spec Alignment Review
+
+## Executive Summary
+- The repository delivers a focused "Hidden-Gem Scanner" pipeline that ingests CoinGecko price data, DefiLlama protocol metrics, and Etherscan contract metadata, then assembles a GemScore and markdown artifact per token via a Tree-of-Thought execution plan.【F:src/core/clients.py†L34-L105】【F:src/core/pipeline.py†L80-L199】【F:src/services/exporter.py†L195-L214】
+- Narrative and feature scoring are implemented with lightweight, deterministic heuristics that emphasise testability rather than the GPT-driven sentiment, meme momentum, and rich feature library promised in the product brief.【F:src/core/narrative.py†L11-L71】【F:src/core/features.py†L108-L147】【F:src/core/scoring.py†L10-L67】
+- Critical roadmap items from VoidBloom Data Oracle v1—multi-source news/social ingestion, alerting, dashboard visualisation, backtesting, and reinforcement loops—remain unimplemented in the codebase despite being marked complete in the README checklist.【F:README.md†L84-L106】【F:main.py†L16-L125】
+
+## Alignment by Capability
+
+### Data Ingestion & Normalisation
+| Spec Expectation | Repository Implementation | Gap |
+| --- | --- | --- |
+| Aggregate news, social, on-chain, technical, repo activity, and tokenomics feeds into a unified store. | Only HTTP clients for CoinGecko (market data), DefiLlama (protocol metrics), and Etherscan (contract metadata) are defined, and the demo pipeline runs against offline stubs for these three sources.【F:src/core/clients.py†L34-L105】【F:main.py†L16-L85】 | Social, GitHub, and richer tokenomics sources are absent; the new RSS `NewsAggregator` surfaces curated feeds but lacks persistence and broader data infusion.【F:src/services/news.py†L12-L126】【F:README.md†L84-L135】 |
+| Persist historical payloads, embeddings, and search indices. | No persistence layer is wired; the demo writes markdown artifacts to disk without databases or embeddings.【F:main.py†L101-L125】【F:src/services/exporter.py†L195-L214】 | Requires database schema, vector storage, and ingestion history management. |
+
+### Feature Engineering & Scoring
+| Spec Expectation | Repository Implementation | Gap |
+| --- | --- | --- |
+| Compute GemScore from rich sentiment (NVI), meme momentum, liquidity depth, tokenomics risk, community growth, etc., blending multiple windows and decay factors. | Feature vector normalises liquidity, wallet activity, net inflows, unlock pressure, and holder counts, while GemScore weights match the MVP distribution listed in the spec.【F:src/core/features.py†L108-L147】【F:src/core/scoring.py†L10-L67】 | Lacks advanced indicators (EMA/MACD variants beyond basics, ATR, Bollinger), meme metrics, narrative embeddings, and dynamic weight tuning/backtesting. |
+| Provide confidence via recency × completeness and support multi-window aggregation. | Recency and data completeness are calculated directly inside the pipeline before GemScore evaluation.【F:src/core/pipeline.py†L429-L446】 | No evidence of cross-window averaging, decay schedules, or learning loops the roadmap calls for. |
+
+### Safety & Risk Controls
+| Spec Expectation | Repository Implementation | Gap |
+| --- | --- | --- |
+| Contract safety gate with exploit detection, owner privilege analysis, liquidity floors, and tokenomics filters. | Safety module penalises liquidity below a configurable threshold and checks contract metadata for verification, mint/withdraw functions, and honeypot tags, feeding a SafetyReport into feature penalties.【F:src/core/safety.py†L10-L45】【F:src/core/pipeline.py†L300-L371】 | Missing static analysis depth (upgradeable proxies, pausable roles), third-party audit ingestion, rug heuristics, and integration with external scanners. |
+
+### Narrative Intelligence
+| Spec Expectation | Repository Implementation | Gap |
+| --- | --- | --- |
+| GPT-powered Narrative Volatility Index, meme momentum, archetypal clustering, and lore-ready summaries. | NarrativeAnalyzer counts positive/negative keywords to derive sentiment, momentum, and top tokens, enabling deterministic tests but not generative insights.【F:src/core/narrative.py†L11-L71】 | Needs LLM-powered embeddings, meme tracking, narrative clustering, and lore generation pipeline. |
+
+### Outputs & Workflow
+| Spec Expectation | Repository Implementation | Gap |
+| --- | --- | --- |
+| Deliver ranked dashboard, charts, alerts, and Obsidian/PDF “Collapse Artifacts,” with human-in-the-loop review cadence. | The Tree-of-Thought pipeline culminates in a markdown Collapse Artifact rendered by `render_markdown_artifact`, and the CLI can print or persist these files.【F:src/core/pipeline.py†L205-L228】【F:src/services/exporter.py†L195-L299】【F:src/cli/run_scanner.py†L92-L154】 | No web dashboard, charts, alert integrations, PDF exporter, or review workflows (watchlists, approvals). |
+| Continuous feedback loop (precision@K, backtests, weight tuning) with scheduled runs. | There is no scheduling, telemetry, or evaluation harness in the repository; the README’s checklist marking these tasks complete is aspirational.【F:README.md†L84-L135】 | Requires job scheduler, logging, analytics, and training scripts. |
+
+## Additional Observations
+- The README asserts completion of news/social ingestion, SQLite persistence, meme momentum, and visualization deliverables that are not reflected in the Python implementation, risking stakeholder misalignment.【F:README.md†L84-L109】【F:main.py†L16-L125】
+- The Tree-of-Thought structure provides a solid foundation for explainable reasoning and could be extended to branch into narrative or safety subtrees once new data sources arrive.【F:src/core/pipeline.py†L117-L228】
+- Artifact rendering is markdown-only; extending `render_markdown_artifact` to HTML/PDF would better serve the “Lore Capsule” requirement.【F:src/services/exporter.py†L195-L299】
+
+## Recommended Next Steps
+1. **Implement missing ingestion channels** (news, social, GitHub, tokenomics) with persistence to SQLite + vector storage, aligning code with the documented data infusion layer.【F:src/core/clients.py†L34-L105】【F:README.md†L84-L135】
+2. **Upgrade narrative and meme analytics** by integrating embedding models or LLM services that deliver the promised Narrative Volatility Index and lore-ready summaries.【F:src/core/narrative.py†L11-L71】
+3. **Expand safety analysis** to include advanced contract heuristics, liquidity depth checks across venues, and third-party audit feeds before exposing scores to users.【F:src/core/safety.py†L10-L45】
+4. **Ship user-facing outputs**—web dashboard, alerting channels, and PDF exporters—to transform markdown artifacts into operational tooling consistent with the roadmap.【F:src/services/exporter.py†L195-L299】【F:README.md†L103-L115】
+5. **Establish evaluation loops and scheduling** so GemScore precision, confidence calibration, and weight tuning can evolve through real-world feedback.【F:src/core/scoring.py†L10-L67】【F:README.md†L96-L135】

--- a/src/cli/run_scanner.py
+++ b/src/cli/run_scanner.py
@@ -1,18 +1,20 @@
 """Command-line interface to execute the Hidden-Gem Scanner pipeline."""
-
 from __future__ import annotations
 
 import argparse
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
+from typing import Callable, Iterable, List, Tuple
 
 import yaml
 
-from src.core.clients import CoinGeckoClient, DefiLlamaClient, EtherscanClient
-from src.core.pipeline import HiddenGemScanner, TokenConfig, UnlockEvent
+from src.core.clients import CoinGeckoClient, DefiLlamaClient, EtherscanClient, NewsFeedClient
+from src.core.pipeline import HiddenGemScanner, ScanResult, TokenConfig, UnlockEvent
 from src.core.narrative import NarrativeAnalyzer
+from src.services.exporter import save_artifact
+from src.services.news import NewsAggregator
 
 
 def load_config(path: Path) -> dict:
@@ -26,6 +28,145 @@ def build_unlocks(raw_unlocks: Iterable[dict]) -> list[UnlockEvent]:
         date = datetime.fromisoformat(item["date"]).replace(tzinfo=timezone.utc)
         unlocks.append(UnlockEvent(date=date, percent_supply=float(item["percent_supply"])))
     return unlocks
+
+
+def _artifact_filename(symbol: str, timestamp: datetime) -> str:
+    """Return a filesystem-safe filename for an artifact."""
+
+    safe_symbol = re.sub(r"[^a-z0-9]+", "-", symbol.lower()).strip("-") or "token"
+    safe_timestamp = timestamp.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{safe_symbol}-{safe_timestamp}.md"
+
+
+def _ensure_clients(
+    *,
+    coin_client: CoinGeckoClient | None,
+    defi_client: DefiLlamaClient | None,
+    etherscan_client: EtherscanClient | None,
+    etherscan_api_key: str | None,
+) -> Tuple[CoinGeckoClient, DefiLlamaClient, EtherscanClient, List[Callable[[], None]]]:
+    """Return concrete clients and cleanup callbacks."""
+
+    cleanups: List[Callable[[], None]] = []
+
+    if coin_client is None:
+        coin_client = CoinGeckoClient()
+        cleanups.append(coin_client.close)
+    if defi_client is None:
+        defi_client = DefiLlamaClient()
+        cleanups.append(defi_client.close)
+    if etherscan_client is None:
+        etherscan_client = EtherscanClient(api_key=etherscan_api_key)
+        cleanups.append(etherscan_client.close)
+
+    return coin_client, defi_client, etherscan_client, cleanups
+
+
+def _ensure_news_aggregator(
+    *,
+    news_aggregator: NewsAggregator | None,
+    config: dict,
+    cleanups: List[Callable[[], None]],
+) -> NewsAggregator | None:
+    if news_aggregator is not None:
+        return news_aggregator
+
+    default_feeds = config.get("news_feeds") or config.get("news", {}).get("feeds") or []
+    token_has_feeds = any(token.get("news_feeds") for token in config.get("tokens", []))
+    if not default_feeds and not token_has_feeds:
+        return None
+
+    news_client = NewsFeedClient()
+    cleanups.append(news_client.close)
+    return NewsAggregator(news_client, default_feeds=list(default_feeds))
+
+
+def run(
+    config: dict,
+    *,
+    tree: bool = False,
+    tree_format: str = "pretty",
+    output_dir: Path | None = None,
+    coin_client: CoinGeckoClient | None = None,
+    defi_client: DefiLlamaClient | None = None,
+    etherscan_client: EtherscanClient | None = None,
+    narrative_analyzer: NarrativeAnalyzer | None = None,
+    news_aggregator: NewsAggregator | None = None,
+) -> list[ScanResult]:
+    """Execute the scanner for ``config`` and optionally persist artifacts."""
+
+    liquidity_threshold = float(config.get("scanner", {}).get("liquidity_threshold", 50_000))
+    coin_client, defi_client, etherscan_client, cleanups = _ensure_clients(
+        coin_client=coin_client,
+        defi_client=defi_client,
+        etherscan_client=etherscan_client,
+        etherscan_api_key=config.get("etherscan_api_key"),
+    )
+    news_aggregator = _ensure_news_aggregator(
+        news_aggregator=news_aggregator,
+        config=config,
+        cleanups=cleanups,
+    )
+
+    analyzer = narrative_analyzer or NarrativeAnalyzer()
+    scanner = HiddenGemScanner(
+        coin_client=coin_client,
+        defi_client=defi_client,
+        etherscan_client=etherscan_client,
+        narrative_analyzer=analyzer,
+        news_aggregator=news_aggregator,
+        liquidity_threshold=liquidity_threshold,
+    )
+
+    results: list[ScanResult] = []
+
+    try:
+        for token in config.get("tokens", []):
+            token_config = TokenConfig(
+                symbol=token["symbol"],
+                coingecko_id=token["coingecko_id"],
+                defillama_slug=token["defillama_slug"],
+                contract_address=token["contract_address"],
+                narratives=token.get("narratives", []),
+                glyph=token.get("glyph", "⧗⟡"),
+                unlocks=build_unlocks(token.get("unlocks", [])),
+                news_feeds=token.get("news_feeds", []),
+                keywords=token.get("keywords") or [token["symbol"]],
+            )
+            if tree:
+                result, tree_obj = scanner.scan_with_tree(token_config)
+            else:
+                result = scanner.scan(token_config)
+                tree_obj = None
+
+            print(f"=== {token_config.symbol} ===")
+            print(
+                f"GemScore: {result.gem_score.score:.2f} (confidence {result.gem_score.confidence:.1f})"
+            )
+            print(f"Flagged: {'yes' if result.flag else 'no'}")
+            print(result.artifact_markdown)
+            print()
+
+            if output_dir is not None:
+                filename = _artifact_filename(token_config.symbol, result.market_snapshot.timestamp)
+                path = save_artifact(result.artifact_markdown, output_dir, filename)
+                print(f"Saved artifact to {path}")
+                print()
+
+            if tree and tree_obj is not None:
+                if tree_format == "json":
+                    print(json.dumps(tree_obj.to_dict(), indent=2))
+                else:
+                    for line in _render_tree(tree_obj):
+                        print(line)
+                print()
+
+            results.append(result)
+    finally:
+        for cleanup in cleanups:
+            cleanup()
+
+    return results
 
 
 def main() -> None:
@@ -42,48 +183,21 @@ def main() -> None:
         default="pretty",
         help="Rendering format for the Tree-of-Thought trace",
     )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory to persist rendered artifacts",
+    )
     args = parser.parse_args()
 
     config = load_config(args.config)
-    liquidity_threshold = float(config.get("scanner", {}).get("liquidity_threshold", 50_000))
-
-    with CoinGeckoClient() as coin_client, DefiLlamaClient() as defi_client, EtherscanClient(
-        api_key=config.get("etherscan_api_key")
-    ) as etherscan_client:
-        scanner = HiddenGemScanner(
-            coin_client=coin_client,
-            defi_client=defi_client,
-            etherscan_client=etherscan_client,
-            narrative_analyzer=NarrativeAnalyzer(),
-            liquidity_threshold=liquidity_threshold,
-        )
-
-        for token in config.get("tokens", []):
-            token_config = TokenConfig(
-                symbol=token["symbol"],
-                coingecko_id=token["coingecko_id"],
-                defillama_slug=token["defillama_slug"],
-                contract_address=token["contract_address"],
-                narratives=token.get("narratives", []),
-                glyph=token.get("glyph", "⧗⟡"),
-                unlocks=build_unlocks(token.get("unlocks", [])),
-            )
-            if args.tree:
-                result, tree = scanner.scan_with_tree(token_config)
-            else:
-                result = scanner.scan(token_config)
-            print(f"=== {token_config.symbol} ===")
-            print(f"GemScore: {result.gem_score.score:.2f} (confidence {result.gem_score.confidence:.1f})")
-            print(f"Flagged: {'yes' if result.flag else 'no'}")
-            print(result.artifact_markdown)
-            print()
-            if args.tree:
-                if args.tree_format == "json":
-                    print(json.dumps(tree.to_dict(), indent=2))
-                else:
-                    for line in _render_tree(tree):
-                        print(line)
-                print()
+    run(
+        config,
+        tree=args.tree,
+        tree_format=args.tree_format,
+        output_dir=args.output_dir,
+    )
 
 
 def _render_tree(node, indent: int = 0) -> list[str]:

--- a/src/services/news.py
+++ b/src/services/news.py
@@ -1,0 +1,158 @@
+"""Utilities for aggregating news feeds into narrative signals."""
+
+from __future__ import annotations
+
+import calendar
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, List, Sequence
+
+from src.core.clients import NewsFeedClient
+
+
+@dataclass
+class NewsItem:
+    """Normalized representation of a news article."""
+
+    title: str
+    summary: str
+    link: str
+    source: str
+    published_at: datetime | None
+
+
+class NewsAggregator:
+    """Fetch and filter news items from configured feeds."""
+
+    def __init__(
+        self,
+        client: NewsFeedClient,
+        *,
+        default_feeds: Sequence[str] | None = None,
+        max_per_feed: int = 25,
+    ) -> None:
+        self._client = client
+        self._default_feeds = list(default_feeds or [])
+        self._max_per_feed = max(1, int(max_per_feed))
+
+    def collect(
+        self,
+        *,
+        feeds: Sequence[str] | None = None,
+        keywords: Sequence[str] | None = None,
+        limit: int = 50,
+    ) -> List[NewsItem]:
+        """Return normalised items filtered by ``keywords``.
+
+        Parameters
+        ----------
+        feeds:
+            Explicit feed URLs to query. Falls back to the aggregator's
+            ``default_feeds`` when omitted.
+        keywords:
+            Optional case-insensitive keywords that must appear in either the
+            title or summary. When omitted the aggregator returns all
+            articles.
+        limit:
+            Hard cap on the number of items returned across all feeds.
+        """
+
+        feed_urls = list(feeds or self._default_feeds)
+        if not feed_urls:
+            return []
+
+        normalized_keywords = [kw.lower() for kw in (keywords or []) if kw and kw.strip()]
+        results: List[NewsItem] = []
+
+        for url in feed_urls:
+            try:
+                parsed = self._client.fetch_feed(url)
+            except Exception:
+                # Network hiccups should not fail the entire pipeline; we
+                # simply skip the problematic source.
+                continue
+
+            entries = list(getattr(parsed, "entries", []) or [])
+            feed_meta = getattr(parsed, "feed", {}) or {}
+            source_title = str(feed_meta.get("title") or feed_meta.get("link") or url)
+
+            for entry in entries[: self._max_per_feed]:
+                item = _entry_to_item(entry, source_title)
+                if item is None:
+                    continue
+                if normalized_keywords and not _matches(item, normalized_keywords):
+                    continue
+                results.append(item)
+
+        # Deduplicate by link + title to avoid duplicate syndication hits.
+        deduped: List[NewsItem] = []
+        seen: set[str] = set()
+        for item in sorted(results, key=_sort_key, reverse=True):
+            key = item.link or f"{item.source}|{item.title}"
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(item)
+            if len(deduped) >= limit:
+                break
+
+        return deduped
+
+
+def _matches(item: NewsItem, keywords: Iterable[str]) -> bool:
+    haystack = f"{item.title} {item.summary}".lower()
+    return any(keyword in haystack for keyword in keywords)
+
+
+def _entry_to_item(entry: object, source: str) -> NewsItem | None:
+    title = _get(entry, "title") or ""
+    summary = _get(entry, "summary") or _get(entry, "description") or ""
+    link = _get(entry, "link") or ""
+    published = _parse_datetime(entry)
+
+    if not title and not summary:
+        return None
+
+    clean_title = title.strip() or summary.strip()[:80]
+    clean_summary = summary.strip()
+
+    return NewsItem(
+        title=clean_title,
+        summary=clean_summary,
+        link=link.strip(),
+        source=source,
+        published_at=published,
+    )
+
+
+def _parse_datetime(entry: object) -> datetime | None:
+    for attr in ("published_parsed", "updated_parsed"):
+        struct = getattr(entry, attr, None) or _get(entry, attr)
+        if struct:
+            try:
+                return datetime.fromtimestamp(calendar.timegm(struct), tz=timezone.utc)
+            except (OverflowError, TypeError, ValueError):
+                continue
+
+    for attr in ("published", "updated"):
+        raw = _get(entry, attr)
+        if not raw:
+            continue
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            continue
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    return None
+
+
+def _sort_key(item: NewsItem) -> datetime:
+    return item.published_at or datetime.fromtimestamp(0, tz=timezone.utc)
+
+
+def _get(entry: object, key: str):
+    if isinstance(entry, dict):
+        return entry.get(key)
+    return getattr(entry, key, None)

--- a/tests/test_cli_run_scanner.py
+++ b/tests/test_cli_run_scanner.py
@@ -1,0 +1,101 @@
+"""Tests for the CLI scanner helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from src.cli.run_scanner import _artifact_filename, run
+from src.core.narrative import NarrativeAnalyzer
+from src.services.news import NewsItem
+
+
+class StubCoinGeckoClient:
+    def fetch_market_chart(self, token_id: str):  # noqa: D401 - stub
+        base = datetime.now(timezone.utc) - timedelta(days=3)
+        prices = []
+        volumes = []
+        for i in range(4):
+            timestamp = base + timedelta(days=i)
+            prices.append([int(timestamp.timestamp() * 1000), 1.0 + 0.05 * i])
+            volumes.append([int(timestamp.timestamp() * 1000), 15000 + 500 * i])
+        return {"prices": prices, "total_volumes": volumes}
+
+
+class StubDefiLlamaClient:
+    def fetch_protocol(self, slug: str):  # noqa: D401 - stub
+        base = datetime.now(timezone.utc) - timedelta(days=5)
+        tvl = []
+        for idx in range(6):
+            timestamp = base + timedelta(days=idx)
+            tvl.append({"date": int(timestamp.timestamp()), "totalLiquidityUSD": 80_000 + 2_500 * idx})
+        return {
+            "tvl": tvl,
+            "metrics": {"activeUsers": 420 + 5 * (len(tvl) - 1), "holders": 5_000},
+        }
+
+
+class StubEtherscanClient:
+    def fetch_contract_source(self, address: str):  # noqa: D401 - stub
+        return {
+            "IsVerified": "true",
+            "ABI": "function mint(address,uint256) public {}",
+            "SourceCode": "contract Token { function withdraw() public {} }",
+            "SecuritySeverity": "low",
+            "HolderCount": "5000",
+        }
+
+
+class StubNewsAggregator:
+    def collect(self, *, feeds=None, keywords=None, limit=50):  # noqa: D401 - stub
+        return [
+            NewsItem(
+                title="Token expands",
+                summary="Launch momentum continues.",
+                link="https://example.com/token",
+                source="Feed",
+                published_at=datetime.now(timezone.utc),
+            )
+        ]
+
+
+def test_run_saves_artifact(tmp_path: Path) -> None:
+    config = {
+        "scanner": {"liquidity_threshold": 10_000},
+        "tokens": [
+            {
+                "symbol": "My Token",
+                "coingecko_id": "my-token",
+                "defillama_slug": "my-token",
+                "contract_address": "0x123",
+                "narratives": [
+                    "My Token announces mainnet launch with strong growth",
+                    "Partnership momentum stays bullish",
+                ],
+                "unlocks": [
+                    {"date": (datetime.now(timezone.utc) + timedelta(days=30)).isoformat(), "percent_supply": 5},
+                ],
+            }
+        ],
+    }
+
+    analyzer = NarrativeAnalyzer()
+    results = run(
+        config,
+        output_dir=tmp_path,
+        coin_client=StubCoinGeckoClient(),
+        defi_client=StubDefiLlamaClient(),
+        etherscan_client=StubEtherscanClient(),
+        narrative_analyzer=analyzer,
+        news_aggregator=StubNewsAggregator(),
+    )
+
+    assert len(results) == 1
+    result = results[0]
+    expected_name = _artifact_filename("My Token", result.market_snapshot.timestamp)
+    artifact_path = tmp_path / expected_name
+    assert artifact_path.exists()
+    content = artifact_path.read_text(encoding="utf-8")
+    assert "Memorywear Entry" in content
+    assert result.news_items
+    assert "## News Highlights" in content

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -34,6 +34,15 @@ def test_render_markdown_artifact_generates_dashboard_sections() -> None:
         "narratives": ["Theme A", "Theme B"],
         "data_snapshot": ["Point 1", "Point 2"],
         "actions": ["Monitor exchange listings"],
+        "news_items": [
+            {
+                "title": "Story",
+                "summary": "A concise description of developments.",
+                "link": "https://example.com/story",
+                "source": "Feed",
+                "published_at": "2024-01-01T00:00:00Z",
+            }
+        ],
     }
 
     markdown = render_markdown_artifact(payload)
@@ -44,6 +53,9 @@ def test_render_markdown_artifact_generates_dashboard_sections() -> None:
     assert "Momentum" in markdown  # feature table entry
     assert "## Diagnostics" in markdown
     assert "Theme A" in markdown
+    assert "## News Highlights" in markdown
+    assert "**Feed** — Story" in markdown
+    assert "https://example.com/story" in markdown
     assert "# Data Snapshot" in markdown
     assert "Monitor exchange listings" in markdown
 

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,0 +1,57 @@
+"""Tests for news aggregation utilities."""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+from src.services.news import NewsAggregator, NewsItem
+
+
+class StubNewsClient:
+    def __init__(self, feeds: dict[str, list[dict[str, object]]]) -> None:
+        self._feeds = feeds
+
+    def fetch_feed(self, url: str):  # noqa: D401 - stub
+        entries = self._feeds.get(url, [])
+        return SimpleNamespace(entries=entries, feed={"title": url})
+
+
+def _entry(title: str, summary: str, link: str, timestamp: int) -> dict[str, object]:
+    return {
+        "title": title,
+        "summary": summary,
+        "link": link,
+        "published_parsed": time.gmtime(timestamp),
+    }
+
+
+def test_news_aggregator_filters_by_keyword() -> None:
+    feeds = {
+        "feed-a": [
+            _entry("Token ABC surges", "Positive developments", "a", 1_700_000_000),
+            _entry("Macro news", "Unrelated", "b", 1_700_000_100),
+        ],
+    }
+    aggregator = NewsAggregator(StubNewsClient(feeds), default_feeds=["feed-a"], max_per_feed=5)
+
+    items = aggregator.collect(keywords=["ABC"], limit=5)
+
+    assert len(items) == 1
+    assert isinstance(items[0], NewsItem)
+    assert items[0].title == "Token ABC surges"
+
+
+def test_news_aggregator_deduplicates_links_across_feeds() -> None:
+    shared_entry = _entry("Token ABC surges", "Duplicate", "shared", 1_700_000_000)
+    feeds = {
+        "feed-a": [shared_entry],
+        "feed-b": [shared_entry],
+    }
+
+    aggregator = NewsAggregator(StubNewsClient(feeds), default_feeds=["feed-a", "feed-b"], max_per_feed=5)
+
+    items = aggregator.collect(limit=10)
+
+    assert len(items) == 1
+    assert items[0].link == "shared"


### PR DESCRIPTION
## Summary
- introduce a reusable NewsAggregator service that normalises RSS/Atom feeds and deduplicates filtered articles for narrative scoring
- wire news collection into the Hidden-Gem Scanner, CLI configuration, and artifact payloads so Collapse Artifacts surface recent headlines alongside sentiment data
- render a News Highlights section in the markdown exporter and cover the feature with new unit tests and spec review updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e21371bdc08320be314c7436a8c857