### PR TITLE
Add HTML artifact rendering and export support

### DIFF
--- a/main.py
+++ b/main.py
@@ -105,6 +105,8 @@ def run_demo() -> List[Tuple[TokenConfig, str, TreeNode]]:
         result, tree = scanner.scan_with_tree(token)
         artifact_path = ARTIFACTS_DIR / f"{token.symbol.lower()}_demo.md"
         artifact_path.write_text(result.artifact_markdown)
+        html_path = ARTIFACTS_DIR / f"{token.symbol.lower()}_demo.html"
+        html_path.write_text(result.artifact_html)
         outputs.append((token, result.artifact_markdown, tree))
     return outputs
 

--- a/src/cli/run_scanner.py
+++ b/src/cli/run_scanner.py
@@ -150,7 +150,10 @@ def run(
             if output_dir is not None:
                 filename = _artifact_filename(token_config.symbol, result.market_snapshot.timestamp)
                 path = save_artifact(result.artifact_markdown, output_dir, filename)
+                html_name = filename[:-3] + ".html" if filename.endswith(".md") else f"{filename}.html"
+                html_path = save_artifact(result.artifact_html, output_dir, html_name)
                 print(f"Saved artifact to {path}")
+                print(f"Saved HTML artifact to {html_path}")
                 print()
 
             if tree and tree_obj is not None:

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -15,7 +15,7 @@ from src.core.narrative import NarrativeAnalyzer, NarrativeInsight
 from src.core.safety import SafetyReport, apply_penalties, evaluate_contract, liquidity_guardrail
 from src.core.scoring import GemScoreResult, compute_gem_score, should_flag_asset
 from src.core.tree import NodeOutcome, TreeNode
-from src.services.exporter import render_markdown_artifact
+from src.services.exporter import render_html_artifact, render_markdown_artifact
 from src.services.news import NewsAggregator, NewsItem
 
 
@@ -51,6 +51,7 @@ class ScanResult:
     debug: Dict[str, float]
     artifact_payload: Dict[str, object]
     artifact_markdown: str
+    artifact_html: str
     news_items: Sequence[NewsItem] = field(default_factory=list)
 
 
@@ -76,6 +77,7 @@ class ScanContext:
     debug: Dict[str, float] = field(default_factory=dict)
     artifact_payload: Dict[str, object] = field(default_factory=dict)
     artifact_markdown: str | None = None
+    artifact_html: str | None = None
     safety_report: SafetyReport | None = None
     liquidity_ok: bool = False
     result: ScanResult | None = None
@@ -602,8 +604,10 @@ class HiddenGemScanner:
             context.news_items,
         )
         markdown = render_markdown_artifact(payload)
+        html = render_html_artifact(payload)
         context.artifact_payload = payload
         context.artifact_markdown = markdown
+        context.artifact_html = html
         context.result = ScanResult(
             token=context.config.symbol,
             market_snapshot=context.snapshot,
@@ -616,6 +620,7 @@ class HiddenGemScanner:
             debug=context.debug,
             artifact_payload=payload,
             artifact_markdown=markdown,
+            artifact_html=html,
             news_items=context.news_items,
         )
         return NodeOutcome(

--- a/tests/test_cli_run_scanner.py
+++ b/tests/test_cli_run_scanner.py
@@ -99,3 +99,8 @@ def test_run_saves_artifact(tmp_path: Path) -> None:
     assert "Memorywear Entry" in content
     assert result.news_items
     assert "## News Highlights" in content
+
+    html_path = tmp_path / expected_name.replace(".md", ".html")
+    assert html_path.exists()
+    html_content = html_path.read_text(encoding="utf-8")
+    assert "<!DOCTYPE html>" in html_content

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 from textwrap import dedent
 
-from src.services.exporter import render_markdown_artifact, save_artifact
+from src.services.exporter import (
+    render_html_artifact,
+    render_markdown_artifact,
+    save_artifact,
+)
 
 
 def test_render_markdown_artifact_handles_missing_fields() -> None:
@@ -90,6 +94,54 @@ def test_render_markdown_artifact_limits_feature_table() -> None:
 
     assert "…" in markdown  # ellipsis row indicates trimming
     assert markdown.count("Metric") <= 13  # 12 entries + ellipsis row
+
+
+def test_render_html_artifact_contains_key_sections() -> None:
+    payload = {
+        "title": "Example",
+        "timestamp": "2024-01-01T00:00:00Z",
+        "glyph": "◇",
+        "gem_score": 82.3456,
+        "confidence": 0.91234,
+        "flags": ["LiquidityFloorPass", "NoAnomalies"],
+        "narrative_sentiment": "positive",
+        "narrative_momentum": 0.4567,
+        "price": 1.2345,
+        "volume_24h": 987654.321,
+        "liquidity": 54321.0,
+        "holders": 1200,
+        "features": {"Momentum": 0.9, "Risk": -0.3},
+        "debug": {"threshold": 0.42},
+        "narratives": ["Theme A", "Theme B"],
+        "data_snapshot": ["Point 1", "Point 2"],
+        "actions": ["Monitor exchange listings"],
+        "lore": "Lore capsule",
+        "news_items": [
+            {
+                "title": "Story",
+                "summary": "A concise description of developments.",
+                "link": "https://example.com/story",
+                "source": "Feed",
+                "published_at": "2024-01-01T00:00:00Z",
+            }
+        ],
+    }
+
+    html = render_html_artifact(payload)
+
+    assert "<!DOCTYPE html>" in html
+    assert "Executive Summary" in html
+    assert "Market Snapshot" in html
+    assert "Narrative Signals" in html
+    assert "News Highlights" in html
+    assert "Lore" in html
+    assert "https://example.com/story" in html
+
+
+def test_render_html_artifact_handles_missing_fields() -> None:
+    html = render_html_artifact({"title": "Test Artifact"})
+    assert "Test Artifact" in html
+    assert "Executive Summary" in html
 
 
 def test_save_artifact_writes_file(tmp_path: Path) -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -68,3 +68,4 @@ def test_hidden_gem_scanner_produces_artifact() -> None:
     assert result.gem_score.score > 0
     assert "Memorywear Entry" in result.artifact_markdown
     assert isinstance(result.artifact_payload["flags"], list)
+    assert "<!DOCTYPE html>" in result.artifact_html


### PR DESCRIPTION
## Summary
- add an HTML renderer for Collapse Artifacts with reusable helpers in the exporter service
- update the scanning pipeline, CLI, and demo runner to capture and persist HTML alongside markdown output
- extend the test suite to cover HTML rendering and ensure CLI runs emit the additional artifact files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e21a1d600c8320a372054c34c469fc