### PR TITLE
feat: add composite metrics to hidden-gem artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,115 @@
 
 This repository contains the foundational skeleton for the VoidBloom Data Oracle, a sophisticated cryptocurrency analysis system that combines multi-source data ingestion, sentiment synthesis, technical intelligence, and contract security analysis.
 
+## 🌌 Vision & Mission
+
+### Mission in One Line
+
+Build a reliable, safety-gated, AI-assisted system that discovers early, high-potential crypto tokens before retail hype, then translates those signals into ranked dashboards, actionable alerts, and mythic “Collapse Artifact” reports you can publish, sell, or archive as lore.
+
+### The Problem It Solves (Bluntly)
+
+- Noise > Signal. Thousands of tokens, shallow reporting, coordinated shilling.
+- Fragmented data. On-chain, order books, GitHub, social—never in one place.
+- Security blind spots. Great narratives can hide unsafe contracts and toxic tokenomics.
+- Creative moat missing. Pure quant tools don’t build brand, community, or artifacts.
+
+This project fuses quant + narrative + security into a single pipeline with a human-in-the-loop, and aestheticizes the output so it becomes both research and product.
+
+### Concrete Objectives
+
+1. Surface hidden gems early by ranking tokens with a multi-signal **GemScore** blending on-chain accumulation, technicals, sentiment/narrative momentum, liquidity depth, tokenomics, and contract safety.
+2. Block obvious rugs/exploits via a contract safety gate that checks owner privileges, mintability, upgradeability, and exploit patterns.
+3. Make the signal usable with a dashboard (ranked list + charts), alerts (Telegram/Slack), and Obsidian exports for daily operations.
+4. Create monetizable artifacts: high-score tokens become “Lore Capsules” rendered as collectible reports with codex glyphs and poetic captioning.
+5. Continuously learn by backtesting, measuring precision@K, and re-weighting features in a recursive improvement loop.
+6. Stay human-controlled—no auto-trading, no custody; the system suggests, you decide.
+
+### Scope (What It Will Do)
+
+- Ingest multi-source data: price/volume, TVL, whale flows, contract metadata, tokenomics, headlines/social snippets, GitHub commits.
+- Normalize then feature-ize: technical indicators (RSI/MACD/MAs), accumulation metrics, liquidity depth, unlock schedules, narrative embeddings.
+- Score & rank tokens with GemScore (0–100) and a Confidence metric, gating everything through safety checks.
+- Output top candidates with charts, risk notes, and “Collapse Artifact” PDFs while logging feedback for iterative improvement.
+
+### Non-Goals (What It Won’t Do)
+
+- Hold keys, place trades, promise returns, or provide financial advice.
+- Replace diligence; it accelerates and augments it.
+
+## 🧠 System at a Glance
+
+**Inputs → Transforms → Outputs**
+
+**Inputs**: On-chain (Etherscan/The Graph/DefiLlama), market data (CoinGecko/exchange APIs), social/news snippets (X, Reddit, headlines), GitHub activity, tokenomics (supply, unlocks, vesting).
+
+**Transforms**: Feature extraction (technicals, accumulation, liquidity), narrative embeddings and clustering (NVI), contract safety analysis (privileges, proxies, mintability), ensemble scoring with time decay.
+
+**Outputs**: Web dashboard (ranked tokens + drilldowns), alerts (score jumps, safety changes), Collapse Artifact reports (Obsidian/PDF zines), API for ecosystem reuse.
+
+## 🧮 Core Scoring Model
+
+Features (normalized 0–1): Sentiment/Narrative (S, NVI), Accumulation (A), On-chain activity (O), Liquidity depth (L), Tokenomics risk (T), Contract safety (C), Meme momentum (M), Community growth (G).
+
+Example weighting (MVP): S:0.15, A:0.20, O:0.15, L:0.10, T:0.12, C:0.12, M:0.08, G:0.08 → Σ=1.0.
+
+**GemScore** = Σ (wᵢ·featureᵢ) reported 0–100 with a separate Confidence score. A safety gate penalizes or blocks assets with severe contract flags or ultra-thin liquidity.
+
+## 👥 Who Uses It and How
+
+- **Researcher-Architect**: Reviews the top list daily, opens token drilldowns, interprets risk notes, and determines watchlists or tranche sizes.
+- **Community/Collectors**: Consume stylized Lore Capsules, purchase memorywear PDFs, and follow dashboard updates.
+- **Collaborators/Analysts**: Extend data sources, refine heuristics, or craft add-on playbooks.
+
+### User Stories
+
+- “Alert me when a token hits GemScore ≥ 70 with Confidence ≥ 0.75 and no upcoming unlock cliffs.”
+- “Export the top 5 weekly as Artifact PDFs with glyphs + a 120-word poetic caption.”
+
+## 📏 Success Metrics
+
+- **Signal quality**: precision@10 (7/30/90-day windows), median forward return vs. baseline, max drawdown on flagged list.
+- **Timeliness**: median lead time between flag and mainstream coverage.
+- **Safety**: % of blocked assets later flagged as risky by third parties.
+- **Adoption**: dashboard DAUs, alert subscriptions, artifact downloads/sales.
+- **Learning speed**: improvement in precision after each re-weighting cycle.
+
+## 🛡️ Risks & Mitigations
+
+- **Data bias / survivorship** → Use broad historical datasets, time-split backtests, and log false positives/negatives.
+- **Overfitting** → Keep weights simple and interpretable; validate out-of-sample; favor orthogonal features.
+- **Security theater** → Gate on objective contract checks, link to evidence, retain human sign-off.
+- **Ethical drift** → Publish safety findings, include disclaimers, avoid auto-execution, maintain provenance logs.
+- **API fragility / rate limits** → Cache, queue, degrade gracefully, and rotate sources.
+
+## 📦 Deliverables
+
+- Next.js (or Streamlit) dashboard with ranked tokens, mini-charts, and risk badges.
+- Telegram/Slack alerts with GemScore, Confidence, and key flags.
+- Obsidian export + printable PDF “Lore Capsule” template with glyphs, charts, and prose.
+- Python ETL + scoring notebook for reproducible runs and audits.
+- Backtest harness and report (precision@K, forward returns, ablation study).
+- README + architecture diagram for collaborators.
+
+## 📅 Operating Cadence
+
+- **Every 4 hours**: ingest → score → update dashboard → push alerts.
+- **Daily**: human review of top 10; publish 1–3 Lore Capsules.
+- **Weekly**: backtest + weight tuning; publish a “Mythic Market Brief.”
+- **Monthly**: feature ablation + safety rules refresh; roadmap iteration.
+
+## 🗺️ Roadmap (Compressed)
+
+1. **Phase 1**: Ingest (price/on-chain/contract), compute GemScore, CLI/notebook output.
+2. **Phase 2**: Dashboard + safety gate + alerts.
+3. **Phase 3**: Narrative embeddings (NVI) + Obsidian/PDF artifact pipeline.
+4. **Phase 4**: Backtests, auto-tuning, community publishing flow.
+5. **Phase 5**: Enrichment (wallet clustering, DEX depth models), partner feeds.
+
+## 🧭 Why It Matters
+
+Edge arises from curated data, risk gating, and a recursive workflow—not just the model. The system transforms signals into mythic evidence, minting market intelligence as ritualized culture.
+
 ## 📁 Repository Structure
 
 ```
@@ -147,6 +256,9 @@ Final Score = (0.4 × APS) + (0.3 × NVI) + (0.2 × ERR⁻¹) + (0.1 × RRR)
 
 ### Testing
 ```bash
+# Python unit tests
+pytest
+
 # Python syntax check
 python3 -m py_compile main.py
 

--- a/src/cli/run_scanner.py
+++ b/src/cli/run_scanner.py
@@ -143,6 +143,7 @@ def run(
             print(
                 f"GemScore: {result.gem_score.score:.2f} (confidence {result.gem_score.confidence:.1f})"
             )
+            print(f"Final Score: {result.final_score:.2f}")
             print(f"Flagged: {'yes' if result.flag else 'no'}")
             print(result.artifact_markdown)
             print()

--- a/src/core/narrative.py
+++ b/src/core/narrative.py
@@ -39,6 +39,8 @@ class NarrativeInsight:
     sentiment_score: float
     momentum: float
     themes: List[str]
+    volatility: float
+    meme_momentum: float
 
 
 class NarrativeAnalyzer:
@@ -47,15 +49,25 @@ class NarrativeAnalyzer:
     def analyze(self, narratives: Iterable[str]) -> NarrativeInsight:
         texts = [text.strip().lower() for text in narratives if text.strip()]
         if not texts:
-            return NarrativeInsight(sentiment_score=0.5, momentum=0.5, themes=[])
+            return NarrativeInsight(
+                sentiment_score=0.5,
+                momentum=0.5,
+                themes=[],
+                volatility=0.0,
+                meme_momentum=0.0,
+            )
 
         scores: List[float] = []
         token_counter: Counter[str] = Counter()
+        meme_hits = 0
+        token_count = 0
         for text in texts:
             tokens = [token.strip(".,!?") for token in text.split()]
             token_counter.update(tokens)
             positive_hits = sum(1 for token in tokens if token in _POSITIVE_TOKENS)
             negative_hits = sum(1 for token in tokens if token in _NEGATIVE_TOKENS)
+            meme_hits += sum(1 for token in tokens if token in _POSITIVE_TOKENS)
+            token_count += len(tokens)
             magnitude = positive_hits + negative_hits
             if magnitude == 0:
                 sentiment = 0.5
@@ -68,4 +80,17 @@ class NarrativeAnalyzer:
         momentum = float(np.clip((scores[-1] - scores[0]) * 0.5 + 0.5 if len(scores) > 1 else sentiment_score, 0.0, 1.0))
         themes = [token for token, _ in token_counter.most_common(5) if len(token) >= 5]
 
-        return NarrativeInsight(sentiment_score=sentiment_score, momentum=momentum, themes=themes)
+        volatility = float(np.clip(np.std(scores) * 2.0, 0.0, 1.0))
+        if token_count == 0:
+            meme_momentum = 0.0
+        else:
+            meme_ratio = meme_hits / token_count
+            meme_momentum = float(np.clip(0.5 + meme_ratio, 0.0, 1.0))
+
+        return NarrativeInsight(
+            sentiment_score=sentiment_score,
+            momentum=momentum,
+            themes=themes,
+            volatility=volatility,
+            meme_momentum=meme_momentum,
+        )

--- a/src/services/exporter.py
+++ b/src/services/exporter.py
@@ -314,6 +314,7 @@ def render_markdown_artifact(payload: Dict[str, object]) -> str:
     glyph = payload.get("glyph", "⧗⟡")
     gem_score = _format_number(payload.get("gem_score", "N/A"), precision=2)
     confidence = _format_number(payload.get("confidence", "N/A"), precision=2)
+    final_score = _format_number(payload.get("final_score", "N/A"), precision=2)
     nvi = _format_number(payload.get("nvi", 0.0), precision=2)
     flags = _coerce_lines(payload.get("flags", []))
     lore = payload.get("lore", "")
@@ -322,6 +323,9 @@ def render_markdown_artifact(payload: Dict[str, object]) -> str:
     narratives = _coerce_lines(payload.get("narratives", []))
     hash_value = payload.get("hash")
     news_section_lines = _format_news_section(payload.get("news_items", []))
+    sentiment_metric_lines = _format_mapping_section(payload.get("sentiment_metrics"), precision=3)
+    technical_metric_lines = _format_mapping_section(payload.get("technical_metrics"), precision=3)
+    security_metric_lines = _format_mapping_section(payload.get("security_metrics"), precision=3)
 
     header_lines = [
         "---",
@@ -330,6 +334,7 @@ def render_markdown_artifact(payload: Dict[str, object]) -> str:
         f'glyph: "{glyph}"',
         f"GemScore: {gem_score}",
         f"Confidence: {confidence}",
+        f"FinalScore: {final_score}",
         f"NVI: {nvi}",
         "Flags:",
     ]
@@ -343,6 +348,7 @@ def render_markdown_artifact(payload: Dict[str, object]) -> str:
     summary_lines = _make_bullet_list(
         [
             f"**GemScore:** {gem_score} (confidence {confidence})",
+            f"**Final Score:** {final_score}",
             f"**Flags:** {', '.join(flags) if flags else 'None'}",
             f"**Narrative Sentiment:** {payload.get('narrative_sentiment', 'unknown')}",
         ]
@@ -395,6 +401,9 @@ def render_markdown_artifact(payload: Dict[str, object]) -> str:
         Section("Executive Summary", summary_lines, level=1).render(),
         Section("Market Snapshot", market_section_lines, level=2).render(),
         Section("Narrative Signals", narrative_section_lines, level=2).render(),
+        Section("Sentiment Metrics", sentiment_metric_lines, level=2).render(),
+        Section("Technical Metrics", technical_metric_lines, level=2).render(),
+        Section("Security Metrics", security_metric_lines, level=2).render(),
         Section("News Highlights", news_section_lines, level=2).render(),
         Section("Feature Vector Highlights", feature_lines, level=2).render(),
         Section("Diagnostics", debug_lines, level=2).render(),
@@ -424,6 +433,7 @@ def render_html_artifact(payload: Dict[str, object]) -> str:
     glyph = str(payload.get("glyph", "⧗⟡"))
     gem_score = _format_number(payload.get("gem_score", "N/A"), precision=2)
     confidence = _format_number(payload.get("confidence", "N/A"), precision=2)
+    final_score = _format_number(payload.get("final_score", "N/A"), precision=2)
     nvi = _format_number(payload.get("nvi", 0.0), precision=2)
     sentiment = str(payload.get("narrative_sentiment", "unknown"))
     momentum = payload.get("narrative_momentum")
@@ -449,9 +459,13 @@ def render_html_artifact(payload: Dict[str, object]) -> str:
 
     feature_rows = _mapping_rows(payload.get("features"), precision=3, limit=12)
     debug_rows = _mapping_rows(payload.get("debug"), precision=3, limit=12)
+    sentiment_rows = _mapping_rows(payload.get("sentiment_metrics"), precision=3, limit=12)
+    technical_rows = _mapping_rows(payload.get("technical_metrics"), precision=3, limit=12)
+    security_rows = _mapping_rows(payload.get("security_metrics"), precision=3, limit=12)
 
     summary_items = [
         f"GemScore: {gem_score} (confidence {confidence})",
+        f"Final Score: {final_score}",
         f"Flags: {', '.join(flags) if flags else 'None'}",
         f"Narrative Sentiment: {sentiment}",
     ]
@@ -502,6 +516,7 @@ pre { white-space: pre-wrap; }
                     "<div class=\"summary-grid\">",
                     f"  <p><strong>GemScore:</strong> {escape(gem_score)}</p>",
                     f"  <p><strong>Confidence:</strong> {escape(confidence)}</p>",
+                    f"  <p><strong>Final Score:</strong> {escape(final_score)}</p>",
                     f"  <p><strong>NVI:</strong> {escape(nvi)}</p>",
                     f"  <p><strong>Flags:</strong> {flag_badges}</p>",
                     f"  <p><strong>Sentiment:</strong> {escape(sentiment)}</p>",
@@ -528,6 +543,9 @@ pre { white-space: pre-wrap; }
                 ]
             ),
         ),
+        ("Sentiment Metrics", _render_table_html(sentiment_rows)),
+        ("Technical Metrics", _render_table_html(technical_rows)),
+        ("Security Metrics", _render_table_html(security_rows)),
         ("News Highlights", news_html),
         ("Feature Vector Highlights", _render_table_html(feature_rows)),
         ("Diagnostics", _render_table_html(debug_rows)),

--- a/tests/test_cli_run_scanner.py
+++ b/tests/test_cli_run_scanner.py
@@ -99,6 +99,8 @@ def test_run_saves_artifact(tmp_path: Path) -> None:
     assert "Memorywear Entry" in content
     assert result.news_items
     assert "## News Highlights" in content
+    assert "Final Score" in content
+    assert result.final_score >= 0
 
     html_path = tmp_path / expected_name.replace(".md", ".html")
     assert html_path.exists()

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -26,6 +26,7 @@ def test_render_markdown_artifact_generates_dashboard_sections() -> None:
         "glyph": "◇",
         "gem_score": 82.3456,
         "confidence": 0.91234,
+        "final_score": 88.123,
         "flags": ["LiquidityFloorPass", "NoAnomalies"],
         "narrative_sentiment": "positive",
         "narrative_momentum": 0.4567,
@@ -35,6 +36,9 @@ def test_render_markdown_artifact_generates_dashboard_sections() -> None:
         "holders": 1200,
         "features": {"Momentum": 0.9, "Risk": -0.3},
         "debug": {"threshold": 0.42},
+        "sentiment_metrics": {"NVI": 0.42, "MMS": 0.73},
+        "technical_metrics": {"APS": 0.61, "RRR": 0.58},
+        "security_metrics": {"ERR": 0.2, "ACI": 0.8},
         "narratives": ["Theme A", "Theme B"],
         "data_snapshot": ["Point 1", "Point 2"],
         "actions": ["Monitor exchange listings"],
@@ -57,6 +61,9 @@ def test_render_markdown_artifact_generates_dashboard_sections() -> None:
     assert "Momentum" in markdown  # feature table entry
     assert "## Diagnostics" in markdown
     assert "Theme A" in markdown
+    assert "## Sentiment Metrics" in markdown
+    assert "## Technical Metrics" in markdown
+    assert "## Security Metrics" in markdown
     assert "## News Highlights" in markdown
     assert "**Feed** — Story" in markdown
     assert "https://example.com/story" in markdown
@@ -93,7 +100,8 @@ def test_render_markdown_artifact_limits_feature_table() -> None:
     markdown = render_markdown_artifact(payload)
 
     assert "…" in markdown  # ellipsis row indicates trimming
-    assert markdown.count("Metric") <= 13  # 12 entries + ellipsis row
+    feature_section = markdown.split("## Feature Vector Highlights", 1)[1].split("## Diagnostics", 1)[0]
+    assert feature_section.count("Metric") <= 13  # 12 entries + ellipsis row
 
 
 def test_render_html_artifact_contains_key_sections() -> None:
@@ -103,6 +111,7 @@ def test_render_html_artifact_contains_key_sections() -> None:
         "glyph": "◇",
         "gem_score": 82.3456,
         "confidence": 0.91234,
+        "final_score": 88.123,
         "flags": ["LiquidityFloorPass", "NoAnomalies"],
         "narrative_sentiment": "positive",
         "narrative_momentum": 0.4567,
@@ -112,6 +121,9 @@ def test_render_html_artifact_contains_key_sections() -> None:
         "holders": 1200,
         "features": {"Momentum": 0.9, "Risk": -0.3},
         "debug": {"threshold": 0.42},
+        "sentiment_metrics": {"NVI": 0.42, "MMS": 0.73},
+        "technical_metrics": {"APS": 0.61, "RRR": 0.58},
+        "security_metrics": {"ERR": 0.2, "ACI": 0.8},
         "narratives": ["Theme A", "Theme B"],
         "data_snapshot": ["Point 1", "Point 2"],
         "actions": ["Monitor exchange listings"],
@@ -133,6 +145,9 @@ def test_render_html_artifact_contains_key_sections() -> None:
     assert "Executive Summary" in html
     assert "Market Snapshot" in html
     assert "Narrative Signals" in html
+    assert "Sentiment Metrics" in html
+    assert "Technical Metrics" in html
+    assert "Security Metrics" in html
     assert "News Highlights" in html
     assert "Lore" in html
     assert "https://example.com/story" in html

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -11,6 +11,8 @@ def test_narrative_analyzer_scores_sentiment() -> None:
     assert 0.0 <= insight.sentiment_score <= 1.0
     assert 0.0 <= insight.momentum <= 1.0
     assert isinstance(insight.themes, list)
+    assert 0.0 <= insight.volatility <= 1.0
+    assert 0.0 <= insight.meme_momentum <= 1.0
 
 
 def test_narrative_analyzer_defaults_without_text() -> None:
@@ -19,3 +21,5 @@ def test_narrative_analyzer_defaults_without_text() -> None:
     assert insight.sentiment_score == 0.5
     assert insight.momentum == 0.5
     assert insight.themes == []
+    assert insight.volatility == 0.0
+    assert insight.meme_momentum == 0.0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -66,6 +66,10 @@ def test_hidden_gem_scanner_produces_artifact() -> None:
     result = scanner.scan(token)
 
     assert result.gem_score.score > 0
+    assert result.final_score >= 0
+    assert "NVI" in result.sentiment_metrics
+    assert "APS" in result.technical_metrics
+    assert "ERR" in result.security_metrics
     assert "Memorywear Entry" in result.artifact_markdown
     assert isinstance(result.artifact_payload["flags"], list)
     assert "<!DOCTYPE html>" in result.artifact_html


### PR DESCRIPTION
## Summary
- extend the narrative analyzer and scanner pipeline to compute narrative, technical, and security metric decks with a weighted final score
- surface the composite metrics inside the CLI output and persisted artifacts, including new markdown and HTML sections
- update exporter and pipeline tests to cover the new sentiment volatility, meme momentum, and final score features

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e21e78f9888320bc6e25a3c030104e