### PR TITLE
Implement ingestion worker with social, GitHub, and tokenomics persistence

### DIFF
--- a/src/core/worker.py
+++ b/src/core/worker.py
@@ -1,15 +1,168 @@
-"""Placeholder ingestion worker."""
+"""Ingestion worker orchestrating multi-source data collection."""
 
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import yaml
+
+from src.core.clients import GitHubClient, NewsFeedClient, SocialFeedClient, TokenomicsClient
+from src.services.github import GitHubActivityAggregator, RepositorySpec
+from src.services.news import NewsAggregator
+from src.services.social import SocialAggregator, SocialStream
+from src.services.storage import IngestionStore
+from src.services.tokenomics import TokenSpec, TokenomicsAggregator
 
 
-def main() -> None:
-    while True:
-        print("[worker] heartbeat", flush=True)
-        time.sleep(60)
+DEFAULT_DB_PATH = Path("artifacts/voidbloom.db")
+DEFAULT_CONFIG_PATH = Path("configs/ingestion.yaml")
 
 
-if __name__ == "__main__":
+@dataclass
+class WorkerConfig:
+    """Runtime configuration for the ingestion worker."""
+
+    poll_interval: float = 900.0
+    news_feeds: Sequence[str] = field(default_factory=list)
+    social_streams: Sequence[SocialStream] = field(default_factory=list)
+    github_repos: Sequence[RepositorySpec] = field(default_factory=list)
+    token_endpoints: Sequence[TokenSpec] = field(default_factory=list)
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, object]) -> "WorkerConfig":
+        poll_interval = float(mapping.get("poll_interval", 900.0))
+
+        news_feeds = [
+            str(feed)
+            for feed in mapping.get("news_feeds", [])
+            if isinstance(feed, str) and feed.strip()
+        ]
+
+        social_streams: list[SocialStream] = []
+        for item in mapping.get("social_feeds", []) or []:
+            if not isinstance(item, Mapping):
+                continue
+            url = str(item.get("url") or "").strip()
+            platform = str(item.get("platform") or "").strip() or "social"
+            if not url:
+                continue
+            social_streams.append(SocialStream(url=url, platform=platform, label=str(item.get("label") or "")))
+
+        github_repos: list[RepositorySpec] = []
+        for repo in mapping.get("github_repos", []) or []:
+            if isinstance(repo, str):
+                try:
+                    github_repos.append(RepositorySpec.from_string(repo))
+                except ValueError:
+                    continue
+
+        token_endpoints: list[TokenSpec] = []
+        for entry in mapping.get("tokenomics", []) or []:
+            if isinstance(entry, Mapping):
+                url = str(entry.get("url") or "").strip()
+                symbol = str(entry.get("symbol") or "").strip()
+                if not url or not symbol:
+                    continue
+                source = str(entry.get("source") or "") or None
+                token_endpoints.append(TokenSpec(symbol=symbol, url=url, source=source))
+
+        return cls(
+            poll_interval=poll_interval,
+            news_feeds=news_feeds,
+            social_streams=social_streams,
+            github_repos=github_repos,
+            token_endpoints=token_endpoints,
+        )
+
+
+class IngestionWorker:
+    """Coordinates data collection and persistence across feeds."""
+
+    def __init__(
+        self,
+        *,
+        store: IngestionStore,
+        config: WorkerConfig,
+        news_aggregator: NewsAggregator | None = None,
+        social_aggregator: SocialAggregator | None = None,
+        github_aggregator: GitHubActivityAggregator | None = None,
+        tokenomics_aggregator: TokenomicsAggregator | None = None,
+    ) -> None:
+        self.store = store
+        self.config = config
+        self.news_aggregator = news_aggregator
+        self.social_aggregator = social_aggregator
+        self.github_aggregator = github_aggregator
+        self.tokenomics_aggregator = tokenomics_aggregator
+
+    def run_once(self) -> None:
+        """Collect feeds once and persist into SQLite."""
+
+        if self.news_aggregator and self.config.news_feeds:
+            news_items = self.news_aggregator.collect(feeds=self.config.news_feeds)
+            self.store.persist_news(news_items)
+
+        if self.social_aggregator and self.config.social_streams:
+            social_posts = self.social_aggregator.collect()
+            self.store.persist_social(social_posts)
+
+        if self.github_aggregator and self.config.github_repos:
+            events = self.github_aggregator.collect()
+            self.store.persist_github(events)
+
+        if self.tokenomics_aggregator and self.config.token_endpoints:
+            snapshots = self.tokenomics_aggregator.collect()
+            self.store.persist_tokenomics(snapshots)
+
+    def run_forever(self) -> None:  # pragma: no cover - long running loop
+        while True:
+            self.run_once()
+            time.sleep(self.config.poll_interval)
+
+
+def load_config(path: Path | None = None) -> WorkerConfig:
+    config_path = path or DEFAULT_CONFIG_PATH
+    if config_path.exists():
+        data = yaml.safe_load(config_path.read_text()) or {}
+        if isinstance(data, Mapping):
+            return WorkerConfig.from_mapping(data)
+    return WorkerConfig()
+
+
+def build_worker(config: WorkerConfig, *, db_path: Path = DEFAULT_DB_PATH) -> IngestionWorker:
+    store = IngestionStore(db_path)
+
+    news_client = NewsFeedClient()
+    social_client = SocialFeedClient()
+    github_client = GitHubClient()
+    tokenomics_client = TokenomicsClient()
+
+    news_aggregator = NewsAggregator(news_client, default_feeds=config.news_feeds)
+    social_aggregator = SocialAggregator(social_client, streams=config.social_streams)
+    github_aggregator = GitHubActivityAggregator(github_client, repositories=config.github_repos)
+    tokenomics_aggregator = TokenomicsAggregator(tokenomics_client, tokens=config.token_endpoints)
+
+    return IngestionWorker(
+        store=store,
+        config=config,
+        news_aggregator=news_aggregator,
+        social_aggregator=social_aggregator,
+        github_aggregator=github_aggregator,
+        tokenomics_aggregator=tokenomics_aggregator,
+    )
+
+
+def main() -> None:  # pragma: no cover - CLI helper
+    config = load_config()
+    worker = build_worker(config)
+    try:
+        worker.run_forever()
+    finally:
+        worker.store.close()
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
     main()

--- a/src/services/github.py
+++ b/src/services/github.py
@@ -1,0 +1,155 @@
+"""GitHub activity aggregation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, List, Mapping, MutableMapping, Sequence
+
+from src.core.clients import GitHubClient
+
+
+@dataclass(frozen=True)
+class RepositorySpec:
+    """Identifier for a GitHub repository."""
+
+    owner: str
+    name: str
+
+    @classmethod
+    def from_string(cls, value: str) -> "RepositorySpec":
+        owner, _, name = value.partition("/")
+        if not owner or not name:
+            raise ValueError(f"Invalid repository spec: {value}")
+        return cls(owner=owner.strip(), name=name.strip())
+
+
+@dataclass
+class GitHubEvent:
+    """Normalized representation of a GitHub activity event."""
+
+    id: str
+    repo: str
+    type: str
+    title: str
+    url: str
+    event_at: datetime | None
+    metadata: MutableMapping[str, object] = field(default_factory=dict)
+
+
+class GitHubActivityAggregator:
+    """Fetch recent GitHub events for configured repositories."""
+
+    def __init__(
+        self,
+        client: GitHubClient,
+        *,
+        repositories: Sequence[RepositorySpec] | None = None,
+        per_repo: int = 30,
+    ) -> None:
+        self._client = client
+        self._repositories = list(repositories or [])
+        self._per_repo = max(1, int(per_repo))
+
+    def collect(self, *, limit: int = 100) -> List[GitHubEvent]:
+        events: List[GitHubEvent] = []
+        for repo in self._repositories:
+            try:
+                payload = self._client.fetch_repo_events(repo.owner, repo.name, per_page=self._per_repo)
+            except Exception:
+                continue
+            for item in payload[: self._per_repo]:
+                normalized = _normalize_event(item, repo)
+                if normalized is None:
+                    continue
+                events.append(normalized)
+
+        deduped: List[GitHubEvent] = []
+        seen: set[str] = set()
+        for event in sorted(events, key=_sort_key, reverse=True):
+            if event.id in seen:
+                continue
+            seen.add(event.id)
+            deduped.append(event)
+            if len(deduped) >= limit:
+                break
+        return deduped
+
+
+def _normalize_event(payload: Mapping[str, object], spec: RepositorySpec) -> GitHubEvent | None:
+    identifier = payload.get("id")
+    if not identifier:
+        return None
+
+    event_type = str(payload.get("type") or "event")
+    repo_name = spec.name
+    repo_obj = payload.get("repo")
+    if isinstance(repo_obj, Mapping):
+        repo_name = str(repo_obj.get("name") or repo_name)
+
+    created_at = payload.get("created_at")
+    event_at = _parse_datetime(created_at)
+
+    title = _extract_title(payload)
+    url = _extract_url(payload)
+
+    metadata: MutableMapping[str, object] = {}
+    if isinstance(payload, Mapping):
+        metadata = {
+            key: value
+            for key, value in payload.items()
+            if key in {"actor", "payload", "public", "created_at"}
+        }
+
+    return GitHubEvent(
+        id=str(identifier),
+        repo=repo_name,
+        type=event_type,
+        title=title,
+        url=url,
+        event_at=event_at,
+        metadata=metadata,
+    )
+
+
+def _extract_title(payload: Mapping[str, object]) -> str:
+    actor = payload.get("actor")
+    actor_login = actor.get("login") if isinstance(actor, Mapping) else ""
+    event_type = payload.get("type") or "event"
+    return f"{actor_login} {event_type}".strip()
+
+
+def _extract_url(payload: Mapping[str, object]) -> str:
+    repo = payload.get("repo")
+    if isinstance(repo, Mapping):
+        url = repo.get("url") or ""
+        if isinstance(url, str):
+            return url
+    payload_url = payload.get("html_url") or payload.get("url")
+    if isinstance(payload_url, str):
+        return payload_url
+    return ""
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        cleaned = value.strip().replace("Z", "+00:00")
+        if not cleaned:
+            return None
+        try:
+            dt = datetime.fromisoformat(cleaned)
+        except ValueError:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    return None
+
+
+def _sort_key(event: GitHubEvent) -> datetime:
+    return event.event_at or datetime.fromtimestamp(0, tz=timezone.utc)
+
+
+__all__ = ["GitHubActivityAggregator", "GitHubEvent", "RepositorySpec"]

--- a/src/services/social.py
+++ b/src/services/social.py
@@ -1,0 +1,163 @@
+"""Social feed aggregation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import re
+from typing import Iterable, List, Mapping, MutableMapping, Sequence
+
+from src.core.clients import SocialFeedClient
+
+
+@dataclass(frozen=True)
+class SocialStream:
+    """Configuration for a social feed endpoint."""
+
+    url: str
+    platform: str
+    label: str | None = None
+
+
+@dataclass
+class SocialPost:
+    """Normalized representation of a social post."""
+
+    id: str
+    platform: str
+    author: str
+    content: str
+    url: str
+    posted_at: datetime | None
+    metrics: MutableMapping[str, float | int] = field(default_factory=dict)
+
+
+class SocialAggregator:
+    """Fetch and normalize social posts across configured streams."""
+
+    def __init__(
+        self,
+        client: SocialFeedClient,
+        *,
+        streams: Sequence[SocialStream] | None = None,
+        max_per_stream: int = 50,
+    ) -> None:
+        self._client = client
+        self._streams = list(streams or [])
+        self._max_per_stream = max(1, int(max_per_stream))
+
+    def collect(self, *, limit: int = 100) -> List[SocialPost]:
+        posts: List[SocialPost] = []
+        for stream in self._streams:
+            try:
+                payload = self._client.fetch_posts(stream.url, limit=self._max_per_stream)
+            except Exception:
+                continue
+            for item in payload[: self._max_per_stream]:
+                normalized = _normalize_post(item, stream)
+                if normalized is None:
+                    continue
+                posts.append(normalized)
+
+        deduped: List[SocialPost] = []
+        seen: set[str] = set()
+        for post in sorted(posts, key=_sort_key, reverse=True):
+            if post.id in seen:
+                continue
+            seen.add(post.id)
+            deduped.append(post)
+            if len(deduped) >= limit:
+                break
+        return deduped
+
+
+def _normalize_post(payload: Mapping[str, object], stream: SocialStream) -> SocialPost | None:
+    content = _string(payload, "content") or _string(payload, "text") or ""
+    content = content.strip()
+    if not content:
+        return None
+
+    author = _string(payload, "author") or _string(payload, "username") or ""
+    url = _string(payload, "url") or _string(payload, "link") or ""
+    timestamp = payload.get("timestamp") or payload.get("created_at") or payload.get("published_at")
+    posted_at = _parse_datetime(timestamp)
+
+    identifier = (
+        _string(payload, "id")
+        or _string(payload, "post_id")
+        or _string(payload, "guid")
+        or url
+        or _hash_identifier(stream.platform, author, content, posted_at)
+    )
+
+    metrics = {}
+    for key in ("likes", "upvotes", "retweets", "replies", "comments", "shares"):
+        value = payload.get(key)
+        if isinstance(value, (int, float)):
+            metrics[key] = value
+
+    return SocialPost(
+        id=str(identifier),
+        platform=stream.platform,
+        author=author.strip(),
+        content=content,
+        url=url,
+        posted_at=posted_at,
+        metrics=metrics,
+    )
+
+
+def _string(payload: Mapping[str, object], key: str) -> str:
+    value = payload.get(key)
+    if isinstance(value, str):
+        return value
+    return ""
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        except (OverflowError, ValueError):
+            return None
+    if isinstance(value, str):
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        cleaned = cleaned.replace("Z", "+00:00")
+        try:
+            dt = datetime.fromisoformat(cleaned)
+        except ValueError:
+            match = re.search(r"(\d{4}-\d{2}-\d{2})", cleaned)
+            if match:
+                try:
+                    return datetime.fromisoformat(match.group(1)).replace(tzinfo=timezone.utc)
+                except ValueError:
+                    return None
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    return None
+
+
+def _hash_identifier(platform: str, author: str, content: str, posted_at: datetime | None) -> str:
+    digest = hashlib.sha256()
+    digest.update(platform.encode("utf-8"))
+    digest.update(b"|")
+    digest.update(author.encode("utf-8"))
+    digest.update(b"|")
+    digest.update(content.encode("utf-8"))
+    digest.update(b"|")
+    digest.update((posted_at.isoformat() if posted_at else "").encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _sort_key(post: SocialPost) -> datetime:
+    return post.posted_at or datetime.fromtimestamp(0, tz=timezone.utc)
+
+
+__all__ = ["SocialAggregator", "SocialPost", "SocialStream"]

--- a/src/services/storage.py
+++ b/src/services/storage.py
@@ -1,0 +1,250 @@
+"""SQLite persistence utilities for ingestion outputs."""
+
+from __future__ import annotations
+
+import json
+import math
+import sqlite3
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from src.services.github import GitHubEvent
+from src.services.news import NewsItem
+from src.services.social import SocialPost
+from src.services.tokenomics import TokenomicsSnapshot
+
+
+EMBEDDING_DIMENSION = 64
+
+
+@dataclass
+class IngestionStore:
+    """Lightweight SQLite-backed store for feed aggregation results."""
+
+    path: Path
+
+    def __post_init__(self) -> None:
+        self.path = Path(self.path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self.path))
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._ensure_schema()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+    def _ensure_schema(self) -> None:
+        cursor = self._conn.cursor()
+        cursor.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS news_items (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                summary TEXT,
+                url TEXT,
+                source TEXT,
+                published_at TEXT,
+                fetched_at TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS social_posts (
+                id TEXT PRIMARY KEY,
+                platform TEXT,
+                author TEXT,
+                content TEXT,
+                url TEXT,
+                posted_at TEXT,
+                metrics TEXT,
+                fetched_at TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS github_events (
+                id TEXT PRIMARY KEY,
+                repo TEXT,
+                type TEXT,
+                title TEXT,
+                url TEXT,
+                event_at TEXT,
+                metadata TEXT,
+                fetched_at TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS tokenomics_metrics (
+                token TEXT,
+                metric TEXT,
+                value REAL,
+                unit TEXT,
+                source TEXT,
+                recorded_at TEXT,
+                metadata TEXT,
+                fetched_at TEXT,
+                PRIMARY KEY (token, metric, recorded_at)
+            );
+
+            CREATE TABLE IF NOT EXISTS embeddings (
+                content_id TEXT,
+                kind TEXT,
+                vector TEXT,
+                dimension INTEGER,
+                PRIMARY KEY (content_id, kind)
+            );
+            """
+        )
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def persist_news(self, items: Sequence[NewsItem]) -> None:
+        now = _now_iso()
+        with self._conn:
+            for item in items:
+                identifier = item.link or f"{item.source}|{item.title}"
+                published = item.published_at.isoformat() if item.published_at else None
+                self._conn.execute(
+                    """
+                    INSERT OR IGNORE INTO news_items (id, title, summary, url, source, published_at, fetched_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        identifier,
+                        item.title,
+                        item.summary,
+                        item.link,
+                        item.source,
+                        published,
+                        now,
+                    ),
+                )
+                self._persist_embedding(identifier, "news", f"{item.title}\n{item.summary}")
+
+    def persist_social(self, posts: Sequence[SocialPost]) -> None:
+        now = _now_iso()
+        with self._conn:
+            for post in posts:
+                posted_at = post.posted_at.isoformat() if post.posted_at else None
+                self._conn.execute(
+                    """
+                    INSERT OR IGNORE INTO social_posts (id, platform, author, content, url, posted_at, metrics, fetched_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        post.id,
+                        post.platform,
+                        post.author,
+                        post.content,
+                        post.url,
+                        posted_at,
+                        json.dumps(post.metrics, sort_keys=True),
+                        now,
+                    ),
+                )
+                self._persist_embedding(post.id, "social", post.content)
+
+    def persist_github(self, events: Sequence[GitHubEvent]) -> None:
+        now = _now_iso()
+        with self._conn:
+            for event in events:
+                event_at = event.event_at.isoformat() if event.event_at else None
+                self._conn.execute(
+                    """
+                    INSERT OR REPLACE INTO github_events (id, repo, type, title, url, event_at, metadata, fetched_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        event.id,
+                        event.repo,
+                        event.type,
+                        event.title,
+                        event.url,
+                        event_at,
+                        json.dumps(event.metadata, sort_keys=True),
+                        now,
+                    ),
+                )
+                summary = f"{event.title} {json.dumps(event.metadata, sort_keys=True)}"
+                self._persist_embedding(event.id, "github", summary)
+
+    def persist_tokenomics(self, snapshots: Sequence[TokenomicsSnapshot]) -> None:
+        now = _now_iso()
+        with self._conn:
+            for snapshot in snapshots:
+                recorded = snapshot.recorded_at.isoformat() if snapshot.recorded_at else ""
+                self._conn.execute(
+                    """
+                    INSERT OR REPLACE INTO tokenomics_metrics (token, metric, value, unit, source, recorded_at, metadata, fetched_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        snapshot.token,
+                        snapshot.metric,
+                        snapshot.value,
+                        snapshot.unit,
+                        snapshot.source,
+                        recorded,
+                        json.dumps(snapshot.metadata, sort_keys=True),
+                        now,
+                    ),
+                )
+
+    # ------------------------------------------------------------------
+    # Embeddings
+    # ------------------------------------------------------------------
+    def _persist_embedding(self, content_id: str, kind: str, text: str) -> None:
+        embedding = _bag_of_words_embedding(text)
+        if not embedding:
+            return
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO embeddings (content_id, kind, vector, dimension)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                content_id,
+                kind,
+                json.dumps(embedding),
+                len(embedding),
+            ),
+        )
+
+
+def _bag_of_words_embedding(text: str, *, dimension: int = EMBEDDING_DIMENSION) -> list[float]:
+    tokens = [token for token in _tokenize(text) if token]
+    if not tokens:
+        return []
+    counts = Counter(tokens)
+    total = sum(counts.values())
+    vector = [0.0] * dimension
+    for token, count in counts.items():
+        index = hash(token) % dimension
+        vector[index] += count / total
+    norm = math.sqrt(sum(value * value for value in vector))
+    if norm == 0:
+        return vector
+    return [value / norm for value in vector]
+
+
+def _tokenize(text: str) -> Iterable[str]:
+    word = []
+    for char in text.lower():
+        if char.isalnum():
+            word.append(char)
+        elif word:
+            yield "".join(word)
+            word.clear()
+    if word:
+        yield "".join(word)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+__all__ = ["IngestionStore", "EMBEDDING_DIMENSION"]

--- a/src/services/tokenomics.py
+++ b/src/services/tokenomics.py
@@ -1,0 +1,137 @@
+"""Tokenomics aggregation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, List, Mapping, MutableMapping, Sequence
+
+from src.core.clients import TokenomicsClient
+
+
+@dataclass(frozen=True)
+class TokenSpec:
+    """Configuration describing how to fetch tokenomics for a token."""
+
+    symbol: str
+    url: str
+    source: str | None = None
+
+
+@dataclass
+class TokenomicsSnapshot:
+    """Normalized tokenomics datapoint."""
+
+    token: str
+    metric: str
+    value: float
+    unit: str
+    source: str
+    recorded_at: datetime | None
+    metadata: MutableMapping[str, object] = field(default_factory=dict)
+
+
+class TokenomicsAggregator:
+    """Fetch and flatten tokenomics payloads into structured snapshots."""
+
+    def __init__(
+        self,
+        client: TokenomicsClient,
+        *,
+        tokens: Sequence[TokenSpec] | None = None,
+    ) -> None:
+        self._client = client
+        self._tokens = list(tokens or [])
+
+    def collect(self) -> List[TokenomicsSnapshot]:
+        snapshots: List[TokenomicsSnapshot] = []
+        for token in self._tokens:
+            try:
+                payload = self._client.fetch_token_metrics(token.url)
+            except Exception:
+                continue
+            for snapshot in _flatten_payload(token, payload):
+                snapshots.append(snapshot)
+        return snapshots
+
+
+def _flatten_payload(token: TokenSpec, payload: Mapping[str, object]) -> Iterable[TokenomicsSnapshot]:
+    source = token.source or str(payload.get("source") or "tokenomics")
+    timestamp = payload.get("timestamp") or payload.get("as_of")
+    recorded_at = _parse_datetime(timestamp)
+
+    supply = payload.get("supply")
+    if isinstance(supply, Mapping):
+        for key, value in supply.items():
+            if isinstance(value, (int, float)):
+                yield TokenomicsSnapshot(
+                    token=token.symbol,
+                    metric=f"supply_{key}",
+                    value=float(value),
+                    unit="tokens",
+                    source=source,
+                    recorded_at=recorded_at,
+                )
+
+    metrics = payload.get("metrics")
+    if isinstance(metrics, Mapping):
+        for key, value in metrics.items():
+            if isinstance(value, (int, float)):
+                yield TokenomicsSnapshot(
+                    token=token.symbol,
+                    metric=str(key),
+                    value=float(value),
+                    unit=str(payload.get("unit", "")),
+                    source=source,
+                    recorded_at=recorded_at,
+                )
+
+    unlocks = payload.get("upcoming_unlocks") or payload.get("unlocks")
+    if isinstance(unlocks, Sequence):
+        for entry in unlocks:
+            if not isinstance(entry, Mapping):
+                continue
+            percent = entry.get("percent") or entry.get("percentage")
+            if not isinstance(percent, (int, float)):
+                continue
+            unlock_time = entry.get("date") or entry.get("timestamp")
+            unlock_at = _parse_datetime(unlock_time) or recorded_at
+            metadata: MutableMapping[str, object] = {
+                key: value
+                for key, value in entry.items()
+                if key not in {"percent", "percentage", "date", "timestamp"}
+            }
+            yield TokenomicsSnapshot(
+                token=token.symbol,
+                metric="unlock_percent",
+                value=float(percent),
+                unit="percent",
+                source=source,
+                recorded_at=unlock_at,
+                metadata=metadata,
+            )
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        except (OverflowError, ValueError):
+            return None
+    if isinstance(value, str):
+        cleaned = value.strip().replace("Z", "+00:00")
+        if not cleaned:
+            return None
+        try:
+            dt = datetime.fromisoformat(cleaned)
+        except ValueError:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    return None
+
+
+__all__ = ["TokenomicsAggregator", "TokenomicsSnapshot", "TokenSpec"]

--- a/tests/test_ingestion_worker.py
+++ b/tests/test_ingestion_worker.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+
+from src.core.worker import IngestionWorker, WorkerConfig
+from src.services.github import GitHubEvent, GitHubActivityAggregator, RepositorySpec
+from src.services.news import NewsAggregator, NewsItem
+from src.services.social import SocialAggregator, SocialPost, SocialStream
+from src.services.storage import IngestionStore, EMBEDDING_DIMENSION
+from src.services.tokenomics import TokenSpec, TokenomicsAggregator, TokenomicsSnapshot
+
+
+class StubNewsAggregator(NewsAggregator):
+    def __init__(self) -> None:  # noqa: D401 - stub
+        pass
+
+    def collect(self, *, feeds=None, keywords=None, limit=50):  # noqa: D401 - stub
+        return [
+            NewsItem(
+                title="VoidBloom unlock schedule update",
+                summary="VBM supply unlock reduced by 20%",
+                link="https://example.com/news/vbm",
+                source="ExampleNews",
+                published_at=datetime(2024, 1, 5, tzinfo=timezone.utc),
+            )
+        ]
+
+
+class StubSocialAggregator(SocialAggregator):
+    def __init__(self) -> None:  # noqa: D401 - stub
+        pass
+
+    def collect(self, *, limit=100):  # noqa: D401 - stub
+        return [
+            SocialPost(
+                id="post-1",
+                platform="nitter",
+                author="oracular",
+                content="VBM governance live; TOT community buzzing",
+                url="https://example.com/social/1",
+                posted_at=datetime(2024, 1, 6, 12, tzinfo=timezone.utc),
+                metrics={"likes": 128, "retweets": 32},
+            )
+        ]
+
+
+class StubGitHubAggregator(GitHubActivityAggregator):
+    def __init__(self) -> None:  # noqa: D401 - stub
+        pass
+
+    def collect(self, *, limit=100):  # noqa: D401 - stub
+        return [
+            GitHubEvent(
+                id="evt-1",
+                repo="voidbloom/core",
+                type="PushEvent",
+                title="alice pushed to main",
+                url="https://github.com/voidbloom/core",
+                event_at=datetime(2024, 1, 4, tzinfo=timezone.utc),
+                metadata={"actor": {"login": "alice"}},
+            )
+        ]
+
+
+class StubTokenomicsAggregator(TokenomicsAggregator):
+    def __init__(self) -> None:  # noqa: D401 - stub
+        pass
+
+    def collect(self):  # noqa: D401 - stub
+        return [
+            TokenomicsSnapshot(
+                token="VBM",
+                metric="supply_circulating",
+                value=123_456.0,
+                unit="tokens",
+                source="voidbloom",
+                recorded_at=datetime(2024, 1, 3, tzinfo=timezone.utc),
+                metadata={},
+            ),
+            TokenomicsSnapshot(
+                token="VBM",
+                metric="unlock_percent",
+                value=4.2,
+                unit="percent",
+                source="voidbloom",
+                recorded_at=datetime(2024, 2, 1, tzinfo=timezone.utc),
+                metadata={"cliff": "seed"},
+            ),
+        ]
+
+
+def test_worker_persists_ingestion_payloads(tmp_path) -> None:
+    db_path = tmp_path / "voidbloom.db"
+    store = IngestionStore(db_path)
+    config = WorkerConfig(
+        poll_interval=60.0,
+        news_feeds=["https://example.com/rss"],
+        social_streams=[SocialStream(url="https://example.com/social", platform="nitter")],
+        github_repos=[RepositorySpec(owner="voidbloom", name="core")],
+        token_endpoints=[TokenSpec(symbol="VBM", url="https://example.com/tokenomics")],
+    )
+
+    worker = IngestionWorker(
+        store=store,
+        config=config,
+        news_aggregator=StubNewsAggregator(),
+        social_aggregator=StubSocialAggregator(),
+        github_aggregator=StubGitHubAggregator(),
+        tokenomics_aggregator=StubTokenomicsAggregator(),
+    )
+
+    worker.run_once()
+    worker.run_once()  # ensure idempotency on unique keys
+
+    conn = sqlite3.connect(db_path)
+    news_rows = conn.execute("SELECT id, title, source FROM news_items").fetchall()
+    assert news_rows == [("https://example.com/news/vbm", "VoidBloom unlock schedule update", "ExampleNews")]
+
+    social_rows = conn.execute("SELECT id, platform, author FROM social_posts").fetchall()
+    assert social_rows == [("post-1", "nitter", "oracular")]
+
+    github_rows = conn.execute("SELECT id, repo, type FROM github_events").fetchall()
+    assert github_rows == [("evt-1", "voidbloom/core", "PushEvent")]
+
+    token_rows = conn.execute("SELECT token, metric, value FROM tokenomics_metrics ORDER BY metric").fetchall()
+    assert token_rows == [
+        ("VBM", "supply_circulating", 123_456.0),
+        ("VBM", "unlock_percent", 4.2),
+    ]
+
+    vectors = conn.execute("SELECT dimension, content_id, kind FROM embeddings ORDER BY kind, content_id").fetchall()
+    assert vectors == [
+        (EMBEDDING_DIMENSION, "evt-1", "github"),
+        (EMBEDDING_DIMENSION, "https://example.com/news/vbm", "news"),
+        (EMBEDDING_DIMENSION, "post-1", "social"),
+    ]
+
+    payload = conn.execute("SELECT vector FROM embeddings WHERE content_id='post-1'").fetchone()[0]
+    vector = json.loads(payload)
+    assert len(vector) == EMBEDDING_DIMENSION
+    assert any(abs(value) > 0 for value in vector)
+
+    conn.close()
+    store.close()


### PR DESCRIPTION
## Summary
- add HTTP clients and aggregators for social feeds, GitHub activity, and tokenomics metrics
- implement an ingestion worker that coordinates the new feeds and persists them into a SQLite-backed store with lightweight embeddings
- add tests covering the ingestion worker pipeline and new persistence logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e223c4f3b08320993f15c3e26aa811