### PR TITLE
feat: use GPT-4 for narrative sentiment analysis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests==2.31.0
 nltk==3.8.1
 feedparser==6.0.10
 scikit-learn==1.3.2
+openai==1.35.3

--- a/src/core/narrative.py
+++ b/src/core/narrative.py
@@ -1,37 +1,12 @@
-"""Simple narrative analysis utilities for scoring."""
+"""LLM-backed narrative analysis utilities for scoring."""
 
 from __future__ import annotations
 
-from collections import Counter
+import json
 from dataclasses import dataclass
-from typing import Iterable, List
+from typing import Any, Iterable, List, Optional, Sequence
 
 import numpy as np
-
-_POSITIVE_TOKENS = {
-    "growth",
-    "partnership",
-    "expansion",
-    "bullish",
-    "upgrade",
-    "mainnet",
-    "integration",
-    "surge",
-    "milestone",
-    "launch",
-}
-_NEGATIVE_TOKENS = {
-    "hack",
-    "rug",
-    "exploit",
-    "down",
-    "selloff",
-    "delay",
-    "halt",
-    "bug",
-    "reorg",
-    "bankrupt",
-}
 
 
 @dataclass
@@ -43,11 +18,30 @@ class NarrativeInsight:
     meme_momentum: float
 
 
+_SYSTEM_PROMPT = (
+    "You are Narrative GPT, an analyst focused on cryptocurrency discourse. "
+    "Always respond with a single JSON object containing the keys "
+    "'sentiment', 'sentiment_score', 'emergent_themes', 'memetic_hooks', "
+    "'fake_or_buzz_warning', and 'rationale'."
+)
+
+
 class NarrativeAnalyzer:
-    """Lightweight sentiment estimator built for deterministic tests."""
+    """Narrative analyzer powered by GPT-4 style sentiment synthesis."""
+
+    def __init__(
+        self,
+        *,
+        client: Optional[Any] = None,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.2,
+    ) -> None:
+        self._client = client
+        self._model = model
+        self._temperature = temperature
 
     def analyze(self, narratives: Iterable[str]) -> NarrativeInsight:
-        texts = [text.strip().lower() for text in narratives if text.strip()]
+        texts = [text.strip() for text in narratives if text and text.strip()]
         if not texts:
             return NarrativeInsight(
                 sentiment_score=0.5,
@@ -57,35 +51,32 @@ class NarrativeAnalyzer:
                 meme_momentum=0.0,
             )
 
-        scores: List[float] = []
-        token_counter: Counter[str] = Counter()
-        meme_hits = 0
-        token_count = 0
-        for text in texts:
-            tokens = [token.strip(".,!?") for token in text.split()]
-            token_counter.update(tokens)
-            positive_hits = sum(1 for token in tokens if token in _POSITIVE_TOKENS)
-            negative_hits = sum(1 for token in tokens if token in _NEGATIVE_TOKENS)
-            meme_hits += sum(1 for token in tokens if token in _POSITIVE_TOKENS)
-            token_count += len(tokens)
-            magnitude = positive_hits + negative_hits
-            if magnitude == 0:
-                sentiment = 0.5
-            else:
-                sentiment = (positive_hits - negative_hits) / max(magnitude, 1)
-                sentiment = 0.5 + 0.5 * np.clip(sentiment, -1.0, 1.0)
-            scores.append(float(sentiment))
+        payload = self._request_analysis(texts)
+        sentiment_score = float(np.clip(_as_float(payload.get("sentiment_score"), default=0.5), 0.0, 1.0))
+        themes = _as_str_list(payload.get("emergent_themes"))
+        meme_hooks = _as_str_list(payload.get("memetic_hooks"))
+        fake_warning = bool(payload.get("fake_or_buzz_warning", False))
 
-        sentiment_score = float(np.clip(np.mean(scores), 0.0, 1.0))
-        momentum = float(np.clip((scores[-1] - scores[0]) * 0.5 + 0.5 if len(scores) > 1 else sentiment_score, 0.0, 1.0))
-        themes = [token for token, _ in token_counter.most_common(5) if len(token) >= 5]
-
-        volatility = float(np.clip(np.std(scores) * 2.0, 0.0, 1.0))
-        if token_count == 0:
-            meme_momentum = 0.0
-        else:
-            meme_ratio = meme_hits / token_count
-            meme_momentum = float(np.clip(0.5 + meme_ratio, 0.0, 1.0))
+        momentum = float(
+            np.clip(
+                sentiment_score
+                + 0.15 * (1 if meme_hooks else 0)
+                - 0.2 * (1 if fake_warning else 0),
+                0.0,
+                1.0,
+            )
+        )
+        volatility = float(
+            np.clip(
+                0.25
+                + 0.35 * (1 if fake_warning else 0)
+                + 0.1 * min(len(meme_hooks), 3)
+                + 0.2 * (1 - abs(sentiment_score - 0.5) * 2),
+                0.0,
+                1.0,
+            )
+        )
+        meme_momentum = float(np.clip(0.35 + 0.18 * len(meme_hooks), 0.0, 1.0))
 
         return NarrativeInsight(
             sentiment_score=sentiment_score,
@@ -94,3 +85,69 @@ class NarrativeAnalyzer:
             volatility=volatility,
             meme_momentum=meme_momentum,
         )
+
+    def _request_analysis(self, texts: Sequence[str]) -> dict[str, Any]:
+        """Invoke the LLM and parse the JSON payload it returns."""
+
+        try:
+            response_content = self._invoke_completion(texts)
+        except Exception:
+            return {}
+
+        try:
+            data = json.loads(response_content)
+        except json.JSONDecodeError:
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        return data
+
+    def _invoke_completion(self, texts: Sequence[str]) -> str:
+        """Call the OpenAI client to score the provided narratives."""
+
+        client = self._client or _create_default_openai_client()
+        prompt = self._build_user_prompt(texts)
+        completion = client.chat.completions.create(
+            model=self._model,
+            temperature=self._temperature,
+            response_format={"type": "json_object"},
+            messages=[
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        return completion.choices[0].message.content or ""
+
+    @staticmethod
+    def _build_user_prompt(texts: Sequence[str]) -> str:
+        joined = "\n".join(f"- {text}" for text in texts)
+        return (
+            "Evaluate the following crypto narratives. "
+            "Return the JSON object described by the system instructions with fields populated from your analysis.\n"
+            f"Narratives:\n{joined}"
+        )
+
+
+def _create_default_openai_client() -> Any:
+    try:
+        from openai import OpenAI
+    except ImportError as exc:  # pragma: no cover - triggered only when dependency missing
+        raise RuntimeError("openai package is required for NarrativeAnalyzer") from exc
+    return OpenAI()
+
+
+def _as_float(value: Any, *, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _as_str_list(value: Any) -> List[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    results: List[str] = []
+    for item in value:
+        if isinstance(item, str) and item.strip():
+            results.append(item.strip())
+    return results

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -1,0 +1,31 @@
+"""Test utilities for stubbing external services."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+
+
+class StubOpenAIClient:
+    """Minimal stub that mimics the OpenAI chat completion interface."""
+
+    def __init__(self, payload: Optional[Dict[str, Any]] = None) -> None:
+        if payload is None:
+            payload = {
+                "sentiment": "neutral",
+                "sentiment_score": 0.5,
+                "emergent_themes": ["baseline"],
+                "memetic_hooks": [],
+                "fake_or_buzz_warning": False,
+                "rationale": "Default stub response.",
+            }
+        self.payload = payload
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+        self.invocations: list[Dict[str, Any]] = []
+
+    def _create(self, **kwargs: Any) -> Any:  # noqa: D401 - mimic OpenAI signature
+        self.invocations.append(kwargs)
+        message = SimpleNamespace(content=json.dumps(self.payload))
+        choice = SimpleNamespace(message=message)
+        return SimpleNamespace(choices=[choice])

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -1,18 +1,29 @@
-"""Tests for the lightweight narrative analyzer."""
+"""Tests for the GPT-backed narrative analyzer."""
 
 from __future__ import annotations
 
 from src.core.narrative import NarrativeAnalyzer
+from tests.stubs import StubOpenAIClient
 
 
 def test_narrative_analyzer_scores_sentiment() -> None:
-    analyzer = NarrativeAnalyzer()
+    stub = StubOpenAIClient(
+        payload={
+            "sentiment": "positive",
+            "sentiment_score": 0.82,
+            "emergent_themes": ["growth", "partnership"],
+            "memetic_hooks": ["mainnet hype"],
+            "fake_or_buzz_warning": False,
+            "rationale": "Strong roadmap execution.",
+        }
+    )
+    analyzer = NarrativeAnalyzer(client=stub)
     insight = analyzer.analyze(["Bullish growth and partnership expansion", "Minor delay but launch remains on track"])
-    assert 0.0 <= insight.sentiment_score <= 1.0
+    assert insight.sentiment_score == 0.82
     assert 0.0 <= insight.momentum <= 1.0
-    assert isinstance(insight.themes, list)
+    assert insight.themes == ["growth", "partnership"]
     assert 0.0 <= insight.volatility <= 1.0
-    assert 0.0 <= insight.meme_momentum <= 1.0
+    assert insight.meme_momentum > 0.4
 
 
 def test_narrative_analyzer_defaults_without_text() -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 
 from src.core.pipeline import HiddenGemScanner, TokenConfig, UnlockEvent
 from src.core.narrative import NarrativeAnalyzer
+from tests.stubs import StubOpenAIClient
 
 
 class StubCoinGeckoClient:
@@ -45,11 +46,22 @@ class StubEtherscanClient:
 
 
 def test_hidden_gem_scanner_produces_artifact() -> None:
+    narrative_stub = StubOpenAIClient(
+        payload={
+            "sentiment": "positive",
+            "sentiment_score": 0.74,
+            "emergent_themes": ["growth", "integration"],
+            "memetic_hooks": ["launch hype"],
+            "fake_or_buzz_warning": False,
+            "rationale": "Community momentum with real progress.",
+        }
+    )
+
     scanner = HiddenGemScanner(
         coin_client=StubCoinGeckoClient(),
         defi_client=StubDefiLlamaClient(),
         etherscan_client=StubEtherscanClient(),
-        narrative_analyzer=NarrativeAnalyzer(),
+        narrative_analyzer=NarrativeAnalyzer(client=narrative_stub),
         liquidity_threshold=50_000,
     )
     token = TokenConfig(


### PR DESCRIPTION
## Summary
- replace the keyword-based narrative analyzer with a GPT-4 chat-completion workflow and JSON parsing safeguards
- add an OpenAI dependency and helper utilities for converting LLM output into pipeline metrics
- introduce reusable OpenAI stubs and update tests to validate the new analysis path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e225ee141883209446e3f84cfb2fa3