### PR TITLE
Implement rate-aware ingestion and GPT guardrails

### DIFF
--- a/docs/provider_rate_limits.md
+++ b/docs/provider_rate_limits.md
@@ -1,0 +1,28 @@
+# External Provider Rate Limits & Budgets
+
+This reference captures the enforced request budgets for the ingestion layer as
+implemented by the shared `RateAwareRequester` and persistent ingestion queue.
+The limits are intentionally conservative to protect against upstream bans and
+can be tuned via configuration.
+
+| Provider | Hostname | Budget | Notes |
+| --- | --- | --- | --- |
+| CoinGecko | `api.coingecko.com` | 30 requests / minute | Cached responses for 5 minutes to minimise duplicate fetches. |
+| DefiLlama | `api.llama.fi` | 60 requests / minute | Protocol snapshots cached for 10 minutes. |
+| Etherscan | `api.etherscan.io` | 5 requests / second | Contract lookups cached for 1 hour. |
+| GitHub API | `api.github.com` | 4,500 requests / hour | Repository event polling cached for 2 minutes. |
+| Generic feeds | `*` | 120 requests / minute | Applies to data sources without an explicit budget. |
+
+## Queue Backoff Policies
+
+The SQLite-backed ingestion queue enforces exponential-style backoff windows to
+spread retries across runs:
+
+- News feeds: 5-minute delay after failures before the next lease.
+- Social streams: 2-minute delay after failures.
+- GitHub repositories: 3-minute delay after failures.
+- Tokenomics endpoints: 5-minute delay after failures.
+
+Jobs marked as completed are not re-leased until they are re-enqueued with
+updated payloads, ensuring noise from bursty feeds is smoothed across polling
+cycles.

--- a/src/core/http_manager.py
+++ b/src/core/http_manager.py
@@ -1,0 +1,223 @@
+"""Rate-aware HTTP client helpers with caching and retries."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Dict, Mapping, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+from src.core.rate_limit import RateLimit, RateLimiter
+
+try:  # pragma: no cover - optional dependency
+    import redis
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    redis = None  # type: ignore
+
+
+class CacheBackend:
+    """Minimal cache backend protocol."""
+
+    def get(self, key: str) -> Optional[bytes]:
+        raise NotImplementedError
+
+    def set(self, key: str, value: bytes, ttl: float) -> None:
+        raise NotImplementedError
+
+
+class InMemoryCache(CacheBackend):
+    """Thread-safe in-memory cache with TTL support."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, tuple[float, bytes]] = {}
+
+    def get(self, key: str) -> Optional[bytes]:
+        entry = self._store.get(key)
+        if not entry:
+            return None
+        expires_at, payload = entry
+        if expires_at < time.time():
+            self._store.pop(key, None)
+            return None
+        return payload
+
+    def set(self, key: str, value: bytes, ttl: float) -> None:
+        self._store[key] = (time.time() + ttl, value)
+
+
+class RedisCache(CacheBackend):
+    """Redis-backed cache compatible with the cache protocol."""
+
+    def __init__(self, client: "redis.Redis") -> None:  # type: ignore[name-defined]
+        self._client = client
+
+    def get(self, key: str) -> Optional[bytes]:
+        value = self._client.get(key)
+        return value if isinstance(value, bytes) else None
+
+    def set(self, key: str, value: bytes, ttl: float) -> None:
+        self._client.setex(key, int(ttl), value)
+
+
+@dataclass
+class CachePolicy:
+    ttl_seconds: float = 300.0
+    cache_key: str | None = None
+
+
+class RateAwareRequester:
+    """Wrapper around :class:`httpx.Client` with rate limits, caching, and retries."""
+
+    def __init__(
+        self,
+        client: httpx.Client,
+        *,
+        rate_limits: Mapping[str, RateLimit] | None = None,
+        default_limit: RateLimit | None = None,
+        cache_backend: CacheBackend | None = None,
+        max_retries: int = 3,
+        backoff_factor: float = 1.5,
+        backoff_max: float = 30.0,
+    ) -> None:
+        self._client = client
+        self._limits = {host: RateLimiter(limit) for host, limit in (rate_limits or {}).items()}
+        self._default_limit = RateLimiter(default_limit) if default_limit else None
+        self._cache = cache_backend or InMemoryCache()
+        self._max_retries = max(0, int(max_retries))
+        self._backoff_factor = max(0.5, float(backoff_factor))
+        self._backoff_max = max(1.0, float(backoff_max))
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        cache_policy: CachePolicy | None = None,
+        **kwargs: object,
+    ) -> httpx.Response:
+        method_upper = method.upper()
+        absolute_url = self._absolute_url(url)
+        limiter = self._limiter_for(absolute_url)
+        cache_key = None
+        use_cache = method_upper == "GET" and cache_policy is not None
+        if use_cache:
+            cache_key = cache_policy.cache_key or self._build_cache_key(method_upper, absolute_url, kwargs)
+            cached = self._cache.get(cache_key)
+            if cached is not None:
+                return self._response_from_cache(method_upper, absolute_url, cached)
+
+        attempt = 0
+        while True:
+            if limiter:
+                sleep_for = limiter.acquire()
+                if sleep_for > 0:
+                    time.sleep(sleep_for)
+            try:
+                response = self._client.request(method_upper, url, **kwargs)
+            except httpx.HTTPError:
+                if attempt >= self._max_retries:
+                    raise
+                self._sleep_backoff(attempt)
+                attempt += 1
+                continue
+
+            if response.status_code in {429, 500, 502, 503, 504}:
+                if attempt >= self._max_retries:
+                    response.raise_for_status()
+                retry_after = self._retry_after_seconds(response)
+                backoff = max(retry_after, self._backoff_delay(attempt))
+                time.sleep(min(backoff, self._backoff_max))
+                attempt += 1
+                continue
+
+            response.raise_for_status()
+            if use_cache and cache_key:
+                ttl = cache_policy.ttl_seconds if cache_policy else 0.0
+                if ttl > 0:
+                    payload = json.dumps(
+                        {
+                            "status": response.status_code,
+                            "headers": dict(response.headers),
+                            "content": response.content.decode("latin1"),
+                            "url": absolute_url,
+                        }
+                    ).encode("utf-8")
+                    self._cache.set(cache_key, payload, ttl)
+            return response
+
+    def _limiter_for(self, url: str) -> RateLimiter | None:
+        host = urlparse(url).netloc or ""
+        if host in self._limits:
+            return self._limits[host]
+        return self._default_limit
+
+    def _absolute_url(self, url: str) -> str:
+        if not url:
+            return str(self._client.base_url)
+        base = str(self._client.base_url)
+        if not base:
+            return url
+        try:
+            return str(httpx.URL(base).join(url))
+        except Exception:
+            return url
+
+    @staticmethod
+    def _build_cache_key(method: str, url: str, kwargs: Mapping[str, object]) -> str:
+        normalized = json.dumps({"method": method, "url": url, "kwargs": kwargs}, sort_keys=True, default=str)
+        return sha256(normalized.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _response_from_cache(method: str, url: str, payload: bytes) -> httpx.Response:
+        decoded = json.loads(payload.decode("utf-8"))
+        content = decoded.get("content", "").encode("latin1")
+        status = int(decoded.get("status", 200))
+        headers = decoded.get("headers", {})
+        request = httpx.Request(method, decoded.get("url", url))
+        return httpx.Response(status, content=content, headers=headers, request=request)
+
+    def _sleep_backoff(self, attempt: int) -> None:
+        time.sleep(min(self._backoff_delay(attempt), self._backoff_max))
+
+    def _backoff_delay(self, attempt: int) -> float:
+        return (self._backoff_factor ** (attempt + 1))
+
+    @staticmethod
+    def _retry_after_seconds(response: httpx.Response) -> float:
+        retry_after = response.headers.get("Retry-After")
+        if retry_after is None:
+            return 0.0
+        try:
+            return float(retry_after)
+        except ValueError:
+            return 0.0
+
+
+def build_cache_backend(config: Mapping[str, object] | None = None) -> CacheBackend:
+    """Factory that creates a cache backend from configuration."""
+
+    if config is None:
+        return InMemoryCache()
+    backend = (config.get("backend") if isinstance(config, Mapping) else None) or "memory"
+    backend = str(backend).lower()
+    if backend == "redis":
+        if redis is None:
+            raise RuntimeError("redis backend requested but redis package is not installed")
+        url = str(config.get("url") if isinstance(config, Mapping) else "redis://localhost:6379/0")
+        client = redis.Redis.from_url(url)
+        return RedisCache(client)
+    return InMemoryCache()
+
+
+__all__ = [
+    "CachePolicy",
+    "CacheBackend",
+    "InMemoryCache",
+    "RedisCache",
+    "RateAwareRequester",
+    "build_cache_backend",
+]

--- a/src/core/rate_limit.py
+++ b/src/core/rate_limit.py
@@ -1,0 +1,58 @@
+"""Rate limiting primitives shared by ingestion clients."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from threading import Lock
+from time import monotonic
+from typing import Deque
+
+
+@dataclass(frozen=True)
+class RateLimit:
+    """Simple token bucket style limit."""
+
+    max_requests: int
+    window_seconds: float
+
+    def __post_init__(self) -> None:
+        if self.max_requests <= 0:
+            raise ValueError("max_requests must be positive")
+        if self.window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+
+
+class RateLimiter:
+    """Thread-safe sliding window rate limiter."""
+
+    def __init__(self, limit: RateLimit) -> None:
+        self._limit = limit
+        self._lock = Lock()
+        self._timestamps: Deque[float] = deque()
+
+    def acquire(self) -> float:
+        """Reserve a slot and return required sleep duration in seconds."""
+
+        with self._lock:
+            now = monotonic()
+            self._prune(now)
+            if len(self._timestamps) < self._limit.max_requests:
+                self._timestamps.append(now)
+                return 0.0
+
+            earliest = self._timestamps[0]
+            wait_until = earliest + self._limit.window_seconds
+            wait = max(wait_until - now, 0.0)
+            scheduled = wait_until if wait_until > now else now
+            self._timestamps.append(scheduled)
+            self._timestamps.popleft()
+            return wait
+
+    def _prune(self, current: float) -> None:
+        window_start = current - self._limit.window_seconds
+        while self._timestamps and self._timestamps[0] <= window_start:
+            self._timestamps.popleft()
+
+
+__all__ = ["RateLimit", "RateLimiter"]

--- a/src/services/job_queue.py
+++ b/src/services/job_queue.py
@@ -1,0 +1,159 @@
+"""Persistent job queue used to smooth ingestion bursts."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterator, Mapping
+
+
+@dataclass(frozen=True)
+class JobContext:
+    job_id: int | None
+    kind: str
+    key: str
+    leased: bool = False
+
+
+class PersistentJobQueue:
+    """SQLite backed queue with retry backoff."""
+
+    def __init__(self, path: Path | str) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._path))
+        self._conn.row_factory = sqlite3.Row
+        self._ensure_schema()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def _ensure_schema(self) -> None:
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS ingestion_jobs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                kind TEXT NOT NULL,
+                job_key TEXT NOT NULL,
+                payload TEXT,
+                priority INTEGER NOT NULL DEFAULT 5,
+                status TEXT NOT NULL DEFAULT 'pending',
+                attempts INTEGER NOT NULL DEFAULT 0,
+                not_before REAL,
+                last_error TEXT,
+                updated_at TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                UNIQUE(kind, job_key)
+            );
+            """
+        )
+        self._conn.commit()
+
+    def enqueue(self, kind: str, key: str, payload: Mapping[str, Any] | None = None, *, priority: int = 5) -> JobContext:
+        now = _now()
+        with self._conn:
+            cursor = self._conn.execute(
+                """
+                INSERT INTO ingestion_jobs (kind, job_key, payload, priority, status, attempts, not_before, created_at, updated_at)
+                VALUES (?, ?, ?, ?, 'pending', 0, NULL, ?, ?)
+                ON CONFLICT(kind, job_key)
+                DO UPDATE SET priority=excluded.priority, payload=excluded.payload, updated_at=excluded.updated_at
+                """,
+                (kind, key, json.dumps(payload or {}, sort_keys=True), priority, now, now),
+            )
+        job_id = cursor.lastrowid or self._job_id(kind, key)
+        return JobContext(job_id=job_id, kind=kind, key=key, leased=False)
+
+    def lease(self, kind: str, key: str, *, lease_seconds: float = 30.0) -> JobContext | None:
+        now = time.time()
+        with self._conn:
+            row = self._conn.execute(
+                """
+                SELECT id, status, attempts, not_before FROM ingestion_jobs
+                WHERE kind = ? AND job_key = ?
+                """,
+                (kind, key),
+            ).fetchone()
+            if row is None:
+                return None
+            if row["status"] == "completed":
+                return None
+            not_before = row["not_before"]
+            if not_before and not_before > now:
+                return None
+            self._conn.execute(
+                """
+                UPDATE ingestion_jobs
+                SET status='leased', attempts=attempts+1, not_before=? , updated_at=?
+                WHERE id = ?
+                """,
+                (now + lease_seconds, _now(), row["id"]),
+            )
+        return JobContext(job_id=int(row["id"]), kind=kind, key=key, leased=True)
+
+    @contextmanager
+    def process(
+        self,
+        kind: str,
+        key: str,
+        *,
+        payload: Mapping[str, Any] | None = None,
+        lease_seconds: float = 30.0,
+        backoff_seconds: float = 60.0,
+    ) -> Iterator[JobContext]:
+        base_context = self.enqueue(kind, key, payload)
+        leased = self.lease(kind, key, lease_seconds=lease_seconds)
+        if leased is None:
+            yield base_context
+            return
+        try:
+            yield leased
+        except Exception as exc:
+            self.fail(leased.job_id, str(exc), backoff_seconds=backoff_seconds)
+            raise
+        else:
+            self.complete(leased.job_id)
+
+    def complete(self, job_id: int) -> None:
+        with self._conn:
+            self._conn.execute(
+                """
+                UPDATE ingestion_jobs
+                SET status='completed', not_before=NULL, updated_at=?
+                WHERE id = ?
+                """,
+                (_now(), job_id),
+            )
+
+    def fail(self, job_id: int, error: str, *, backoff_seconds: float = 60.0) -> None:
+        next_run = time.time() + max(backoff_seconds, 1.0)
+        with self._conn:
+            self._conn.execute(
+                """
+                UPDATE ingestion_jobs
+                SET status='pending', not_before=?, last_error=?, updated_at=?
+                WHERE id = ?
+                """,
+                (next_run, error[:512], _now(), job_id),
+            )
+
+    def _job_id(self, kind: str, key: str) -> int:
+        row = self._conn.execute(
+            """SELECT id FROM ingestion_jobs WHERE kind = ? AND job_key = ?""",
+            (kind, key),
+        ).fetchone()
+        if row is None:
+            raise RuntimeError(f"Job {kind}:{key} not found")
+        return int(row["id"])
+
+
+def _now() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+__all__ = ["JobContext", "PersistentJobQueue"]

--- a/src/services/llm_guardrails.py
+++ b/src/services/llm_guardrails.py
@@ -1,0 +1,93 @@
+"""Utilities for caching and budgeting GPT usage."""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Dict, Mapping, Optional
+
+
+class BudgetExceeded(RuntimeError):
+    """Raised when an LLM request would exceed the configured spend ceiling."""
+
+
+def _month_start(now: datetime | None = None) -> datetime:
+    current = now or datetime.now(tz=timezone.utc)
+    return current.replace(day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+
+
+def _estimate_tokens(text: str) -> int:
+    # Cheap approximation: assume 4 characters per token.
+    return max(1, math.ceil(len(text) / 4))
+
+
+@dataclass
+class LLMBudgetGuardrail:
+    """Tracks and enforces a monthly USD budget for GPT usage."""
+
+    monthly_limit_usd: float
+    input_cost_per_1k_tokens: float
+    output_cost_per_1k_tokens: float
+    expected_output_tokens: int = 600
+    usage_usd: float = 0.0
+    window_start: datetime = field(default_factory=_month_start)
+
+    def reserve(self, prompt: str, *, expected_output_tokens: Optional[int] = None) -> float:
+        self._maybe_rollover()
+        tokens_in = _estimate_tokens(prompt)
+        tokens_out = expected_output_tokens or self.expected_output_tokens
+        cost = (tokens_in / 1000.0) * self.input_cost_per_1k_tokens
+        cost += (tokens_out / 1000.0) * self.output_cost_per_1k_tokens
+        if self.usage_usd + cost > self.monthly_limit_usd:
+            raise BudgetExceeded(
+                f"LLM budget exceeded: {self.usage_usd + cost:.2f} > {self.monthly_limit_usd:.2f} USD"
+            )
+        self.usage_usd += cost
+        return cost
+
+    def remaining_budget(self) -> float:
+        self._maybe_rollover()
+        return max(self.monthly_limit_usd - self.usage_usd, 0.0)
+
+    def _maybe_rollover(self) -> None:
+        now = datetime.now(tz=timezone.utc)
+        current_window = _month_start(now)
+        if current_window > self.window_start:
+            self.window_start = current_window
+            self.usage_usd = 0.0
+
+
+class PromptCache:
+    """In-memory TTL cache for prompt/response payloads."""
+
+    def __init__(self, ttl_seconds: float = 86400.0) -> None:
+        self._ttl = ttl_seconds
+        self._entries: Dict[str, tuple[float, Mapping[str, Any]]] = {}
+
+    def get(self, key: str) -> Optional[Mapping[str, Any]]:
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        expires_at, payload = entry
+        if expires_at < time.time():
+            self._entries.pop(key, None)
+            return None
+        return payload
+
+    def set(self, key: str, payload: Mapping[str, Any], *, ttl: Optional[float] = None) -> None:
+        expiry = time.time() + (ttl if ttl is not None else self._ttl)
+        self._entries[key] = (expiry, dict(payload))
+
+    @staticmethod
+    def hash_prompt(prompt: str, *, model: str) -> str:
+        digest = sha256()
+        digest.update(model.encode("utf-8"))
+        digest.update(b"|")
+        digest.update(prompt.encode("utf-8"))
+        return digest.hexdigest()
+
+
+__all__ = ["BudgetExceeded", "LLMBudgetGuardrail", "PromptCache"]

--- a/tests/test_http_manager.py
+++ b/tests/test_http_manager.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import httpx
+
+from src.core.http_manager import CachePolicy, RateAwareRequester
+from src.core.rate_limit import RateLimit, RateLimiter
+
+
+class CallCounter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        return httpx.Response(200, json={"ok": True, "path": str(request.url)})
+
+
+def test_rate_aware_requester_caches_get_requests() -> None:
+    handler = CallCounter()
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport, base_url="https://example.com")
+    requester = RateAwareRequester(
+        client,
+        rate_limits={"example.com": RateLimit(10, 60.0)},
+    )
+
+    first = requester.request("GET", "/resource", cache_policy=CachePolicy(ttl_seconds=60.0))
+    second = requester.request("GET", "/resource", cache_policy=CachePolicy(ttl_seconds=60.0))
+
+    assert first.json() == second.json()
+    assert handler.calls == 1
+
+
+def test_rate_limiter_sliding_window() -> None:
+    limiter = RateLimiter(RateLimit(2, 1.0))
+    assert limiter.acquire() == 0.0
+    assert limiter.acquire() == 0.0
+    wait = limiter.acquire()
+    assert wait >= 0.0

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.services.job_queue import PersistentJobQueue
+
+
+@pytest.fixture()
+def job_queue(tmp_path: Path) -> PersistentJobQueue:
+    queue = PersistentJobQueue(tmp_path / "jobs.db")
+    yield queue
+    queue.close()
+
+
+def test_job_queue_process_completes(job_queue: PersistentJobQueue) -> None:
+    with job_queue.process("news", "feed-a", payload={"url": "https://example.com"}) as job:
+        assert job.leased
+
+    assert job_queue.lease("news", "feed-a") is None
+
+
+def test_job_queue_fail_applies_backoff(job_queue: PersistentJobQueue) -> None:
+    with pytest.raises(RuntimeError):
+        with job_queue.process("social", "stream", backoff_seconds=5.0) as job:
+            assert job.leased
+            raise RuntimeError("boom")
+
+    # Immediately attempting to lease should yield None because the job is backed off.
+    assert job_queue.lease("social", "stream") is None

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from src.core.narrative import NarrativeAnalyzer
+from src.services.llm_guardrails import LLMBudgetGuardrail, PromptCache
 from tests.stubs import StubOpenAIClient
 
 
@@ -34,3 +35,40 @@ def test_narrative_analyzer_defaults_without_text() -> None:
     assert insight.themes == []
     assert insight.volatility == 0.0
     assert insight.meme_momentum == 0.0
+
+
+def test_narrative_analyzer_caches_prompt_responses() -> None:
+    stub = StubOpenAIClient(
+        payload={
+            "sentiment": "positive",
+            "sentiment_score": 0.72,
+            "emergent_themes": ["layer2"],
+            "memetic_hooks": ["#airdrop"],
+            "fake_or_buzz_warning": False,
+            "rationale": "Momentum from scaling news.",
+        }
+    )
+    cache = PromptCache(ttl_seconds=3600)
+    analyzer = NarrativeAnalyzer(client=stub, prompt_cache=cache)
+
+    analyzer.analyze(["Layer2 mainnet growth", "TVL pumping across chains"])
+    analyzer.analyze(["Layer2 mainnet growth", "TVL pumping across chains"])
+
+    assert len(stub.invocations) == 1
+
+
+def test_narrative_analyzer_falls_back_when_budget_hit() -> None:
+    guardrail = LLMBudgetGuardrail(
+        monthly_limit_usd=0.0001,
+        input_cost_per_1k_tokens=0.1,
+        output_cost_per_1k_tokens=0.2,
+    )
+    stub = StubOpenAIClient()
+    analyzer = NarrativeAnalyzer(client=stub, cost_guardrail=guardrail)
+
+    insight = analyzer.analyze(["Exploit on bridge raises community concern"])
+
+    # Guardrail should prevent the remote call so the stub is never invoked.
+    assert len(stub.invocations) == 0
+    assert 0.0 <= insight.sentiment_score <= 1.0
+    assert isinstance(insight.themes, list)


### PR DESCRIPTION
## Summary
- add a shared rate-aware HTTP requester with caching/backoff plus a persistent ingestion job queue, wiring the worker and feed aggregators through it
- document provider budgets and update the roadmap with mitigation status while adding GPT prompt caching and budget guardrails to the narrative analyzer
- cover the new infrastructure with tests for the HTTP requester, job queue, and narrative caching/budget fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e22ed6bb888320a61e72ef7e7a52c1