### PR TITLE
Integrate Groq narrative analysis with fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,24 @@ python3 -m py_compile main.py
 tsc --noEmit
 ```
 
+### Groq LLM Setup
+
+Narrative analysis now uses Groq's high-speed LPU inference API by default. To enable it locally:
+
+1. Create a free account at [console.groq.com](https://console.groq.com) and generate an API key (`gsk_...`).
+2. Install the Python dependency (already listed in `requirements.txt`):
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Export the key or store it in a local `.env` file:
+   ```bash
+   export GROQ_API_KEY="gsk_your_key_here"
+   # or
+   echo "GROQ_API_KEY=gsk_your_key_here" >> .env
+   ```
+
+If the key is missing or the API is unavailable, the analyzer gracefully falls back to deterministic keyword heuristics so tests remain reproducible.
+
 ## 📄 License
 
 This project is part of the CrisisCore-Systems Autotrader initiative.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ requests==2.31.0
 nltk==3.8.1
 feedparser==6.0.10
 scikit-learn==1.3.2
-openai==1.35.3
+groq>=0.4.0

--- a/src/cli/run_scanner.py
+++ b/src/cli/run_scanner.py
@@ -25,7 +25,12 @@ def load_config(path: Path) -> dict:
 def build_unlocks(raw_unlocks: Iterable[dict]) -> list[UnlockEvent]:
     unlocks = []
     for item in raw_unlocks or []:
-        date = datetime.fromisoformat(item["date"]).replace(tzinfo=timezone.utc)
+        raw_date = item["date"]
+        if isinstance(raw_date, datetime):
+            date_value = raw_date
+        else:
+            date_value = datetime.fromisoformat(str(raw_date))
+        date = date_value.replace(tzinfo=timezone.utc)
         unlocks.append(UnlockEvent(date=date, percent_supply=float(item["percent_supply"])))
     return unlocks
 

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -7,8 +7,8 @@ from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
 
-class StubOpenAIClient:
-    """Minimal stub that mimics the OpenAI chat completion interface."""
+class StubGroqClient:
+    """Minimal stub that mimics the Groq chat completion interface."""
 
     def __init__(self, payload: Optional[Dict[str, Any]] = None) -> None:
         if payload is None:
@@ -24,8 +24,12 @@ class StubOpenAIClient:
         self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
         self.invocations: list[Dict[str, Any]] = []
 
-    def _create(self, **kwargs: Any) -> Any:  # noqa: D401 - mimic OpenAI signature
+    def _create(self, **kwargs: Any) -> Any:  # noqa: D401 - mimic Groq signature
         self.invocations.append(kwargs)
         message = SimpleNamespace(content=json.dumps(self.payload))
         choice = SimpleNamespace(message=message)
         return SimpleNamespace(choices=[choice])
+
+
+# Backwards compatibility for older tests/imports
+StubOpenAIClient = StubGroqClient

--- a/tests/test_narrative.py
+++ b/tests/test_narrative.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from src.core.narrative import NarrativeAnalyzer
 from src.services.llm_guardrails import LLMBudgetGuardrail, PromptCache
-from tests.stubs import StubOpenAIClient
+from tests.stubs import StubGroqClient
 
 
 def test_narrative_analyzer_scores_sentiment() -> None:
-    stub = StubOpenAIClient(
+    stub = StubGroqClient(
         payload={
             "sentiment": "positive",
             "sentiment_score": 0.82,
@@ -21,10 +21,10 @@ def test_narrative_analyzer_scores_sentiment() -> None:
     analyzer = NarrativeAnalyzer(client=stub)
     insight = analyzer.analyze(["Bullish growth and partnership expansion", "Minor delay but launch remains on track"])
     assert insight.sentiment_score == 0.82
-    assert 0.0 <= insight.momentum <= 1.0
+    assert insight.momentum == 0.6
     assert insight.themes == ["growth", "partnership"]
-    assert 0.0 <= insight.volatility <= 1.0
-    assert insight.meme_momentum > 0.4
+    assert insight.volatility == 0.3
+    assert insight.meme_momentum == 0.2
 
 
 def test_narrative_analyzer_defaults_without_text() -> None:
@@ -38,7 +38,7 @@ def test_narrative_analyzer_defaults_without_text() -> None:
 
 
 def test_narrative_analyzer_caches_prompt_responses() -> None:
-    stub = StubOpenAIClient(
+    stub = StubGroqClient(
         payload={
             "sentiment": "positive",
             "sentiment_score": 0.72,
@@ -63,7 +63,7 @@ def test_narrative_analyzer_falls_back_when_budget_hit() -> None:
         input_cost_per_1k_tokens=0.1,
         output_cost_per_1k_tokens=0.2,
     )
-    stub = StubOpenAIClient()
+    stub = StubGroqClient()
     analyzer = NarrativeAnalyzer(client=stub, cost_guardrail=guardrail)
 
     insight = analyzer.analyze(["Exploit on bridge raises community concern"])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 
 from src.core.pipeline import HiddenGemScanner, TokenConfig, UnlockEvent
 from src.core.narrative import NarrativeAnalyzer
-from tests.stubs import StubOpenAIClient
+from tests.stubs import StubGroqClient
 
 
 class StubCoinGeckoClient:
@@ -46,7 +46,7 @@ class StubEtherscanClient:
 
 
 def test_hidden_gem_scanner_produces_artifact() -> None:
-    narrative_stub = StubOpenAIClient(
+    narrative_stub = StubGroqClient(
         payload={
             "sentiment": "positive",
             "sentiment_score": 0.74,


### PR DESCRIPTION
## Summary
- integrate the narrative analyzer with Groq's chat completions, including JSON response cleaning, prompt loading, and deterministic fallbacks
- refresh supporting utilities and docs by renaming the LLM stubs, updating tests, fixing unlock parsing, and documenting the new Groq setup requirements
- add the Groq dependency and improve the dashboard API so it can fall back to demo data when real scans fail to produce results

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e23d70e00483208653d215c424a569