### PR TITLE
Address ingestion tree and broker telemetry issues

### DIFF
--- a/src/api/services/cache.py
+++ b/src/api/services/cache.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from typing import Dict, Optional
 
 from ..schemas.token import TokenCacheEntry, TokenSummary
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _parse_iso_timestamp(value: str) -> datetime:
@@ -55,7 +59,11 @@ class TokenCache:
             "timestamp": timestamp,
         }
         normalized_symbol = symbol.upper()
-        print(f"[CACHE PUT] Storing token {normalized_symbol} with symbol in detail: {detail.get('symbol')}")
+        LOGGER.debug(
+            "cache_store symbol=%s detail_symbol=%s",
+            normalized_symbol,
+            detail.get("symbol"),
+        )
         self._entries[normalized_symbol] = entry
         return entry
 
@@ -63,7 +71,12 @@ class TokenCache:
         """Return a cache entry for ``symbol`` if still valid."""
         normalized_symbol = symbol.upper()
         entry = self._entries.get(normalized_symbol)
-        print(f"[CACHE GET] Requesting {normalized_symbol}, found: {entry is not None}, cache keys: {list(self._entries.keys())}")
+        LOGGER.debug(
+            "cache_lookup symbol=%s hit=%s keys=%s",
+            normalized_symbol,
+            entry is not None,
+            list(self._entries.keys()),
+        )
         if not entry:
             return None
 

--- a/src/core/clients.py
+++ b/src/core/clients.py
@@ -84,15 +84,10 @@ class CoinGeckoClient(BaseClient):
         client: Optional[httpx.Client] = None,
     ) -> None:
         session = client or httpx.Client(base_url=base_url, timeout=timeout)
-        super().__init__(session)
-
-    def fetch_market_chart(self, token_id: str, *, vs_currency: str = "usd", days: int = 14) -> Dict[str, Any]:
-        response = self.client.get(
-            f"/coins/{token_id}/market_chart",
-            params={"vs_currency": vs_currency, "days": days},
+        super().__init__(
+            session,
+            rate_limits={"api.coingecko.com": RateLimit(30, 60.0)},
         )
-        response.raise_for_status()
-        super().__init__(session, rate_limits={"api.coingecko.com": RateLimit(30, 60.0)})
 
     def fetch_market_chart(self, token_id: str, *, vs_currency: str = "usd", days: int = 14) -> Dict[str, Any]:
         response = self.requester.request(
@@ -115,12 +110,10 @@ class DefiLlamaClient(BaseClient):
         client: Optional[httpx.Client] = None,
     ) -> None:
         session = client or httpx.Client(base_url=base_url, timeout=timeout)
-        super().__init__(session)
-
-    def fetch_protocol(self, slug: str) -> Dict[str, Any]:
-        response = self.client.get(f"/protocol/{slug}")
-        response.raise_for_status()
-        super().__init__(session, rate_limits={"api.llama.fi": RateLimit(60, 60.0)})
+        super().__init__(
+            session,
+            rate_limits={"api.llama.fi": RateLimit(60, 60.0)},
+        )
 
     def fetch_protocol(self, slug: str) -> Dict[str, Any]:
         response = self.requester.request(

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -348,7 +348,7 @@ class HiddenGemScanner:
         )
         branch_a.add_child(
             TreeNode(
-                key="A5",
+                key="A3",
                 title="Contract Source & Verification",
                 description="Fetch Etherscan contract metadata",
                 action=self._action_fetch_contract_metadata,
@@ -356,7 +356,7 @@ class HiddenGemScanner:
         )
         branch_a.add_child(
             TreeNode(
-                key="A3",
+                key="A4",
                 title="Wallet Clustering",
                 description="Smart-money heuristics staged for enrichment",
                 action=self._action_wallet_clustering_deferred,
@@ -364,7 +364,7 @@ class HiddenGemScanner:
         )
         branch_a.add_child(
             TreeNode(
-                key="A3",
+                key="A5",
                 title="News & Narrative Signals",
                 description="Aggregate news feeds for sentiment context",
                 action=self._action_fetch_news,
@@ -372,7 +372,7 @@ class HiddenGemScanner:
         )
         branch_a.add_child(
             TreeNode(
-                key="A4",
+                key="A6",
                 title="Social & Narrative Streams",
                 description="Memetic signal ingestion queued post-MVP",
                 action=self._action_social_signal_deferred,
@@ -381,7 +381,7 @@ class HiddenGemScanner:
         if self.github_aggregator is not None:
             branch_a.add_child(
                 TreeNode(
-                    key="A4",
+                    key="A7",
                     title="GitHub Activity",
                     description="Collect repository development signals",
                     action=self._action_fetch_github_activity,
@@ -390,24 +390,16 @@ class HiddenGemScanner:
         if self.social_aggregator is not None:
             branch_a.add_child(
                 TreeNode(
-                    key="A4b",
+                    key="A8",
                     title="Social Sentiment",
                     description="Pull high-signal social posts",
                     action=self._action_fetch_social_sentiment,
                 )
             )
-        branch_a.add_child(
-            TreeNode(
-                key="A5",
-                title="Contract Source & Verification",
-                description="Fetch Etherscan contract metadata",
-                action=self._action_fetch_contract_metadata,
-            )
-        )
         if self.tokenomics_aggregator is not None:
             branch_a.add_child(
                 TreeNode(
-                    key="A6",
+                    key="A9",
                     title="Tokenomics Intelligence",
                     description="Normalize circulating supply & unlock data",
                     action=self._action_fetch_tokenomics,
@@ -418,7 +410,7 @@ class HiddenGemScanner:
         if self.derivatives_aggregator is not None:
             branch_a.add_child(
                 TreeNode(
-                    key="A7",
+                    key="A10",
                     title="Derivatives Data",
                     description="Fetch funding rates, open interest, and liquidation data",
                     action=self._action_fetch_derivatives_data,
@@ -427,7 +419,7 @@ class HiddenGemScanner:
         if self.onchain_monitor is not None:
             branch_a.add_child(
                 TreeNode(
-                    key="A8",
+                    key="A11",
                     title="On-chain Flow Analysis",
                     description="Monitor CEX wallet transfers and whale movements",
                     action=self._action_scan_onchain_transfers,
@@ -768,8 +760,8 @@ class HiddenGemScanner:
     def _action_record_ingestion_decision(self, context: ScanContext) -> NodeOutcome:  # noqa: D401 - documentation node
         return NodeOutcome(
             status="success",
-            summary="Executing A1/A2/A5 for MVP; wallet + social streams deferred",
-            data={"active_streams": ["A1", "A2", "A5"], "deferred": ["A3", "A4"]},
+            summary="Executing A1/A2/A3/A5 for MVP; wallet + social streams deferred",
+            data={"active_streams": ["A1", "A2", "A3", "A5"], "deferred": ["A4", "A6"]},
         )
 
     def _action_wallet_clustering_deferred(self, context: ScanContext) -> NodeOutcome:  # noqa: D401 - documentation node

--- a/tests/api/test_scanner_service.py
+++ b/tests/api/test_scanner_service.py
@@ -119,7 +119,7 @@ def test_scanner_uses_free_clients_when_no_etherscan_key(monkeypatch):
     monkeypatch.delenv("ETHERSCAN_API_KEY", raising=False)
 
     service = TokenScannerService()
-    scanner = service._ensure_scanner()
+    scanner = service._create_scanner()
 
     assert scanner.etherscan_client is None
     assert isinstance(scanner.blockscout_client, BlockscoutClient)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -68,8 +68,9 @@ def test_scan_with_tree_emits_trace() -> None:
     statuses = {node.key: (node.outcome.status if node.outcome else None) for node in tree.iter_nodes()}
 
     assert statuses["A1"] == "success"
-    assert statuses["A3"] == "skipped"
+    assert statuses["A3"] == "success"
     assert statuses["A4"] == "skipped"
+    assert statuses["A6"] == "skipped"
     assert statuses["B6"] == "success"
     assert statuses["C2"] == "success"
     assert statuses["C3"] == "success"


### PR DESCRIPTION
## Summary
- deduplicate ingestion tree node keys, update the execution trace test, and stop abusing private scanner APIs
- replace TokenCache print debugging with structured logging, load penny candidates from the curated CSV, and persist the artifact HMAC secret on disk
- propagate stop/target metadata through the IB/Alpaca adapters, wire the microstructure API into the alert manager, and remove duplicated CoinGecko/DefiLlama client methods

## Testing
- pytest tests/test_tree.py tests/test_artifact_integrity.py tests/api/test_scanner_service.py *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68f89e420bb4832084f0470288e5d319