### PR TITLE
Improve API startup resilience tests

### DIFF
--- a/tests/test_api_startup.py
+++ b/tests/test_api_startup.py
@@ -103,13 +103,17 @@ def test_app_initializes_without_required_keys(monkeypatch, caplog):
     fake_tokens_module.router = object()
     fake_health_module = types.ModuleType("src.api.routes.health")
     fake_health_module.router = object()
+    fake_experiments_module = types.ModuleType("src.api.routes.experiments")
+    fake_experiments_module.router = object()
 
     fake_routes_pkg.tokens = fake_tokens_module
     fake_routes_pkg.health = fake_health_module
+    fake_routes_pkg.experiments = fake_experiments_module
 
     monkeypatch.setitem(sys.modules, "src.api.routes", fake_routes_pkg)
     monkeypatch.setitem(sys.modules, "src.api.routes.tokens", fake_tokens_module)
     monkeypatch.setitem(sys.modules, "src.api.routes.health", fake_health_module)
+    monkeypatch.setitem(sys.modules, "src.api.routes.experiments", fake_experiments_module)
     sys.modules.pop(module_name, None)
 
     with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
## Summary
- add lightweight httpx and pydantic stubs in the scanner service test to avoid optional dependency failures
- extend the fallback HiddenGemScanner stub with scan_with_tree so scans can complete under constrained environments
- update the API startup test to stub the experiments router module so imports succeed without FastAPI installed

## Testing
- `pytest tests/test_api_startup.py tests/api/test_scanner_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68f898bced4883208debad66de244fa1