### PR TITLE
Expose GemScore details in backtest reports and document BounceHunter data

### DIFF
--- a/build/lib/src/core/pipeline.py
+++ b/build/lib/src/core/pipeline.py
@@ -82,15 +82,15 @@ class ScanResult:
     artifact_payload: Dict[str, object]
     artifact_markdown: str
     artifact_html: str
-    news_items: Sequence[NewsItem] = field(default_factory=list)
+    news_items: list[NewsItem] = field(default_factory=list)
     sentiment_metrics: Dict[str, float] = field(default_factory=dict)
     technical_metrics: Dict[str, float] = field(default_factory=dict)
     security_metrics: Dict[str, float] = field(default_factory=dict)
     final_score: float = 0.0
-    github_events: Sequence["GitHubEvent"] = field(default_factory=list)
-    social_posts: Sequence["SocialPost"] = field(default_factory=list)
-    tokenomics_metrics: Sequence["TokenomicsSnapshot"] = field(default_factory=list)
-    alerts: Sequence["Alert"] = field(default_factory=list)
+    github_events: list["GitHubEvent"] = field(default_factory=list)
+    social_posts: list["SocialPost"] = field(default_factory=list)
+    tokenomics_metrics: list["TokenomicsSnapshot"] = field(default_factory=list)
+    alerts: list["Alert"] = field(default_factory=list)
     # Phase 3: Derivatives & On-Chain Flow
     derivatives_data: Dict[str, Any] = field(default_factory=dict)
     onchain_alerts: Sequence["OnChainAlert"] = field(default_factory=list)
@@ -123,19 +123,6 @@ class ScanContext:
     liquidity_ok: bool = False
     result: ScanResult | None = None
     artifact_html: str | None = None
-    news_items: Sequence[NewsItem] = field(default_factory=list)
-    sentiment_metrics: Dict[str, float] = field(default_factory=dict)
-    technical_metrics: Dict[str, float] = field(default_factory=dict)
-    security_metrics: Dict[str, float] = field(default_factory=dict)
-    final_score: float = 0.0
-    github_events: Sequence["GitHubEvent"] = field(default_factory=list)
-    social_posts: Sequence["SocialPost"] = field(default_factory=list)
-    tokenomics_metrics: Sequence["TokenomicsSnapshot"] = field(default_factory=list)
-    alerts: Sequence["Alert"] = field(default_factory=list)
-    # Phase 3: Derivatives & On-Chain Flow
-    derivatives_data: Dict[str, Any] = field(default_factory=dict)
-    onchain_alerts: Sequence["OnChainAlert"] = field(default_factory=list)
-    liquidation_spikes: Dict[str, Any] = field(default_factory=dict)
     news_items: list[NewsItem] = field(default_factory=list)
     sentiment_metrics: Dict[str, float] = field(default_factory=dict)
     technical_metrics: Dict[str, float] = field(default_factory=dict)
@@ -144,6 +131,11 @@ class ScanContext:
     github_events: list["GitHubEvent"] = field(default_factory=list)
     social_posts: list["SocialPost"] = field(default_factory=list)
     tokenomics_metrics: list["TokenomicsSnapshot"] = field(default_factory=list)
+    alerts: list["Alert"] = field(default_factory=list)
+    # Phase 3: Derivatives & On-Chain Flow
+    derivatives_data: Dict[str, Any] = field(default_factory=dict)
+    onchain_alerts: Sequence["OnChainAlert"] = field(default_factory=list)
+    liquidation_spikes: Dict[str, Any] = field(default_factory=dict)
 
 
 class HiddenGemScanner:

--- a/scripts/cache_bouncehunter_data.py
+++ b/scripts/cache_bouncehunter_data.py
@@ -1,0 +1,121 @@
+"""Utility to prefetch BounceHunter training data for offline backtests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Iterable, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import pandas as pd
+    from src.bouncehunter.config import BounceHunterConfig
+
+
+def _parse_tickers(raw: str | None) -> list[str] | None:
+    if raw is None:
+        return None
+    tickers = [token.strip().upper() for token in raw.split(",") if token.strip()]
+    return tickers or None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download price history, engineered features, and earnings calendars "
+            "used by BounceHunter so they can be replayed without internet access."
+        )
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("exports/bouncehunter_cache"),
+        help="Directory where cached CSV artifacts will be written.",
+    )
+    parser.add_argument(
+        "--tickers",
+        type=str,
+        help="Optional comma-separated universe override (defaults to BounceHunterConfig.tickers)",
+    )
+    parser.add_argument(
+        "--start",
+        type=str,
+        help="Override the historical start date (YYYY-MM-DD).",
+    )
+    parser.add_argument(
+        "--include-earnings",
+        action="store_true",
+        help="Include signals that fall inside the earnings blackout window when caching data.",
+    )
+    return parser
+
+
+def prepare_config(args: argparse.Namespace) -> "BounceHunterConfig":
+    from src.bouncehunter.config import BounceHunterConfig
+
+    config = BounceHunterConfig()
+    if args.start:
+        config = replace(config, start=args.start)
+    if args.include_earnings:
+        config = replace(config, skip_earnings=False)
+    tickers = _parse_tickers(args.tickers)
+    if tickers:
+        config = config.with_tickers(tickers)
+    return config
+
+
+def write_frame(frame: "pd.DataFrame", path: Path) -> None:
+    frame.to_csv(path, index=True)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    config = prepare_config(args)
+
+    from src.bouncehunter.engine import BounceHunter
+
+    hunter = BounceHunter(config)
+
+    output_dir = args.output
+    histories_dir = output_dir / "histories"
+    features_dir = output_dir / "features"
+    earnings_dir = output_dir / "earnings"
+    aux_dir = output_dir / "auxiliary"
+
+    for directory in (output_dir, histories_dir, features_dir, earnings_dir, aux_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    train_df = hunter.fit()
+
+    metadata = {
+        "tickers": list(config.tickers),
+        "start": config.start,
+        "skip_earnings": config.skip_earnings,
+        "generated_rows": len(train_df),
+    }
+    (output_dir / "metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    write_frame(train_df, output_dir / "training_events.csv")
+
+    for ticker, artifact in hunter._artifacts.items():  # noqa: SLF001 - intentional utility access
+        history_path = histories_dir / f"{ticker}.csv"
+        features_path = features_dir / f"{ticker}.csv"
+        earnings_path = earnings_dir / f"{ticker}.json"
+
+        write_frame(artifact.history, history_path)
+        write_frame(artifact.features, features_path)
+        earnings_payload = [ts.date().isoformat() for ts in artifact.earnings]
+        earnings_path.write_text(json.dumps(earnings_payload, indent=2), encoding="utf-8")
+
+    if hunter._vix_cache is not None:  # noqa: SLF001 - cache populated during fit()
+        vix_frame = hunter._vix_cache.to_frame(name="vix_percentile").reset_index()
+        vix_frame.rename(columns={"index": "date"}, inplace=True)
+        write_frame(vix_frame.set_index("date"), aux_dir / "vix_percentile.csv")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -123,19 +123,6 @@ class ScanContext:
     liquidity_ok: bool = False
     result: ScanResult | None = None
     artifact_html: str | None = None
-    news_items: Sequence[NewsItem] = field(default_factory=list)
-    sentiment_metrics: Dict[str, float] = field(default_factory=dict)
-    technical_metrics: Dict[str, float] = field(default_factory=dict)
-    security_metrics: Dict[str, float] = field(default_factory=dict)
-    final_score: float = 0.0
-    github_events: Sequence["GitHubEvent"] = field(default_factory=list)
-    social_posts: Sequence["SocialPost"] = field(default_factory=list)
-    tokenomics_metrics: Sequence["TokenomicsSnapshot"] = field(default_factory=list)
-    alerts: Sequence["Alert"] = field(default_factory=list)
-    # Phase 3: Derivatives & On-Chain Flow
-    derivatives_data: Dict[str, Any] = field(default_factory=dict)
-    onchain_alerts: Sequence["OnChainAlert"] = field(default_factory=list)
-    liquidation_spikes: Dict[str, Any] = field(default_factory=dict)
     news_items: list[NewsItem] = field(default_factory=list)
     sentiment_metrics: Dict[str, float] = field(default_factory=dict)
     technical_metrics: Dict[str, float] = field(default_factory=dict)
@@ -144,6 +131,11 @@ class ScanContext:
     github_events: list["GitHubEvent"] = field(default_factory=list)
     social_posts: list["SocialPost"] = field(default_factory=list)
     tokenomics_metrics: list["TokenomicsSnapshot"] = field(default_factory=list)
+    alerts: list["Alert"] = field(default_factory=list)
+    # Phase 3: Derivatives & On-Chain Flow
+    derivatives_data: Dict[str, Any] = field(default_factory=dict)
+    onchain_alerts: Sequence["OnChainAlert"] = field(default_factory=list)
+    liquidation_spikes: Dict[str, Any] = field(default_factory=dict)
 
 
 class HiddenGemScanner:


### PR DESCRIPTION
## Summary
- deduplicate the ScanContext state so shared fields no longer shadow prior results
- surface real GemScore scores, confidence, and drivers in the backtest harness while keeping JSON exports in sync
- add an offline caching helper and operator documentation covering BounceHunter data feeds and reproducible workflows

## Testing
- python -m compileall backtest/harness.py scripts/cache_bouncehunter_data.py src/core/pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68f8d9d406ec8320a1dc11ee2a8b2406