### PR TITLE
Document CI baseline risk register

### DIFF
--- a/docs/ci/ci_baseline_risk_register.md
+++ b/docs/ci/ci_baseline_risk_register.md
@@ -1,0 +1,35 @@
+# CI Baseline Risk Register
+
+## Current accepted-risk merges
+
+### PR #120
+Reason: Non-green checks accepted after confirming scoped IBKR harness diff.
+Changed files:
+- .gitignore
+- docs/ibkr/pre_transmit_safety_checkpoint_v0.md
+- scripts/run_ibkr_simulated_signal_paper_harness.py
+
+### PR #121
+Reason: Non-green checks accepted after confirming scoped batch-audit diff.
+Changed files:
+- .gitignore
+- fixtures/ibkr/simulated_signal_batch_001.json
+- scripts/run_ibkr_simulated_signal_batch_audit.py
+
+## Merge policy going forward
+
+Non-green merge is allowed only when:
+- all failing checks are documented
+- changed files are listed
+- failure is proven unrelated to the PR scope
+- no dependency manifests changed
+- no runtime artifacts are included
+- no node_modules are included
+- no broker/live execution code is expanded without passing local safety validation
+
+## Required cleanup
+
+- Identify Dependency Review failure source
+- Identify security-scan baseline failures
+- Separate stale failures from active regressions
+- Add issue links for each unresolved baseline failure


### PR DESCRIPTION
Adds a CI baseline risk register documenting accepted-risk merges for PR #120 and PR #121, the exact scoped files involved, non-green merge policy conditions, and required cleanup actions before further trading capability work.

This is governance-only documentation. It does not modify broker code, strategy code, runtime artifacts, dependency manifests, or execution behavior.