### PR TITLE
Add safety policy config for dependency audit

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,6 @@
+# Safety policy for Python dependency audit.
+# Purpose: restore deterministic CI behavior after security-scan baseline classification.
+# This file should be kept conservative until the dependency review policy is fully governed.
+
+security:
+  ignore-cvss-severity-below: 0


### PR DESCRIPTION
Adds the missing .safety-policy.yml referenced by the Python Dependency Audit step.

This is a focused CI remediation fix for the missing safety policy config classified in Pass 002.

No broker code, strategy code, dependency manifests, runtime artifacts, or trading behavior changed.