### PR TITLE
Allow greenlet composite license expression

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -255,7 +255,7 @@ jobs:
             --format=json \
             --output-file=licenses.json \
             --fail-on="GPL-2.0;GPL-3.0;AGPL-3.0" \
-            --allow-only="MIT;MIT License;Apache-2.0;Apache Software License;Apache License 2.0;Apache-2.0 OR BSD-2-Clause;MIT OR Apache-2.0;BSD License;Apache Software License; BSD License;BSD;BSD-3-Clause;BSD-2-Clause;ISC;ISC License (ISCL);Python-2.0;Python Software Foundation License;PSF-2.0;MPL-2.0;MPL-2.0 AND (Apache-2.0 OR MIT);UNKNOWN;GNU General Public License v2 (GPLv2)"
+            --allow-only="MIT;MIT License;Apache-2.0;Apache Software License;Apache License 2.0;Apache-2.0 OR BSD-2-Clause;MIT OR Apache-2.0;BSD License;Apache Software License; BSD License;BSD;BSD-3-Clause;BSD-2-Clause;ISC;ISC License (ISCL);Python-2.0;Python Software Foundation License;PSF-2.0;MPL-2.0;MPL-2.0 AND (Apache-2.0 OR MIT);MIT AND PSF-2.0;UNKNOWN;GNU General Public License v2 (GPLv2)"
       
       - name: Upload license report
         if: always()

--- a/docs/ci/remediation/pass_004_greenlet_license_governance.md
+++ b/docs/ci/remediation/pass_004_greenlet_license_governance.md
@@ -1,0 +1,35 @@
+# CI Remediation Pass 004: greenlet License Governance
+
+## Linked verification
+
+CI Remediation Verification Pass 001 showed that Prompt Contract Validation and Python Dependency Audit moved past prior failures.
+
+Remaining License Compliance failure:
+
+- Package: greenlet
+- Version: 3.5.0
+- License expression: MIT AND PSF-2.0
+
+## Dependency source
+
+- Direct dependency: no
+- Parent dependency if transitive: SQLAlchemy
+- Project file declaring parent: (not found in requirements.txt, requirements-dev.txt, pyproject.toml, or setup.cfg)
+
+## Governance decision
+
+Decision: accept exact composite expression `MIT AND PSF-2.0`
+
+## Rationale
+
+Both MIT and PSF-2.0 are already accepted license families in the current policy. The failure is caused by the compliance tool reporting the combined SPDX-style expression as a distinct value. The policy should accept the exact composite expression without broadly expanding license families.
+
+## CI policy action
+
+Add exact allow-list entry:
+
+`MIT AND PSF-2.0`
+
+## Boundary
+
+No broker code, strategy code, execution behavior, order sizing, live ports, or trading automation changed.


### PR DESCRIPTION
Documents the governance decision and allows the exact composite license expression 'MIT AND PSF-2.0' for greenlet in the security-scan workflow. No trading, broker, or strategy code changed.