### PR TITLE
Allow regex composite license expression

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -255,7 +255,7 @@ jobs:
             --format=json \
             --output-file=licenses.json \
             --fail-on="GPL-2.0;GPL-3.0;AGPL-3.0" \
-            --allow-only="MIT;MIT License;Apache-2.0;Apache Software License;Apache License 2.0;Apache-2.0 OR BSD-2-Clause;MIT OR Apache-2.0;BSD License;Apache Software License; BSD License;BSD;BSD-3-Clause;BSD-2-Clause;ISC;ISC License (ISCL);Python-2.0;Python Software Foundation License;PSF-2.0;MPL-2.0;MPL-2.0 AND (Apache-2.0 OR MIT);MIT AND PSF-2.0;UNKNOWN;GNU General Public License v2 (GPLv2)"
+            --allow-only="MIT;MIT License;Apache-2.0;Apache Software License;Apache License 2.0;Apache-2.0 OR BSD-2-Clause;MIT OR Apache-2.0;BSD License;Apache Software License; BSD License;BSD;BSD-3-Clause;BSD-2-Clause;ISC;ISC License (ISCL);Python-2.0;Python Software Foundation License;PSF-2.0;MPL-2.0;MPL-2.0 AND (Apache-2.0 OR MIT);MIT AND PSF-2.0;Apache-2.0 AND CNRI-Python;UNKNOWN;GNU General Public License v2 (GPLv2)"
       
       - name: Upload license report
         if: always()

--- a/docs/ci/remediation/pass_006_regex_license_governance.md
+++ b/docs/ci/remediation/pass_006_regex_license_governance.md
@@ -1,0 +1,35 @@
+# CI Remediation Pass 006: regex License Governance
+
+## Linked verification
+
+CI Remediation Verification Pass 002 showed that Python Dependency Audit, Prompt Contract Validation, Bandit, Trivy, Gitleaks, and TruffleHog pass.
+
+Remaining License Compliance failure:
+
+- Package: regex
+- Version: 2026.5.9
+- License expression: Apache-2.0 AND CNRI-Python
+
+## Dependency source
+
+- Direct dependency: no direct `regex` declaration in `requirements.txt`, `requirements-dev.txt`, or `pyproject.toml`
+- Parent dependency if transitive: `nltk==3.9.4` (NLP dependency present in runtime requirements)
+- Project file declaring parent: `requirements.txt`
+
+## Governance decision
+
+Decision: accept exact composite expression `Apache-2.0 AND CNRI-Python`
+
+## Rationale
+
+Apache-2.0 is already accepted by the current policy. CNRI-Python is a Python ecosystem license expression that must be evaluated explicitly. This remediation accepts only the exact composite expression reported by the license tool and does not broadly allow new license families.
+
+## CI policy action
+
+Add exact allow-list entry:
+
+`Apache-2.0 AND CNRI-Python`
+
+## Boundary
+
+No broker code, strategy code, execution behavior, order sizing, live ports, or trading automation changed.


### PR DESCRIPTION
CI Fix 005: regex license governance.

Observed in CI Remediation Verification Pass 002:
- Package: regex
- Version: 2026.5.9
- License expression: Apache-2.0 AND CNRI-Python
- Failure type: license allow-list gap

Changes:
- Adds governance note pass_006_regex_license_governance.md
- Adds only exact allow-list entry Apache-2.0 AND CNRI-Python in security-scan workflow

Boundary:
- No broker code changed
- No strategy code changed
- No execution behavior changed
- No dependency upgrades
- No trading automation changes