### PR TITLE
Allow aiohttp composite license expression

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -255,7 +255,7 @@ jobs:
             --format=json \
             --output-file=licenses.json \
             --fail-on="GPL-2.0;GPL-3.0;AGPL-3.0" \
-            --allow-only="MIT;MIT License;Apache-2.0;Apache Software License;Apache License 2.0;Apache-2.0 OR BSD-2-Clause;MIT OR Apache-2.0;BSD License;Apache Software License; BSD License;BSD;BSD-3-Clause;BSD-2-Clause;ISC;ISC License (ISCL);Python-2.0;Python Software Foundation License;PSF-2.0;MPL-2.0;MPL-2.0 AND (Apache-2.0 OR MIT);MIT AND PSF-2.0;Apache-2.0 AND CNRI-Python;UNKNOWN;GNU General Public License v2 (GPLv2)"
+            --allow-only="MIT;MIT License;Apache-2.0;Apache Software License;Apache License 2.0;Apache-2.0 OR BSD-2-Clause;MIT OR Apache-2.0;BSD License;Apache Software License; BSD License;BSD;BSD-3-Clause;BSD-2-Clause;ISC;ISC License (ISCL);Python-2.0;Python Software Foundation License;PSF-2.0;MPL-2.0;MPL-2.0 AND (Apache-2.0 OR MIT);MIT AND PSF-2.0;Apache-2.0 AND CNRI-Python;Apache-2.0 AND MIT;UNKNOWN;GNU General Public License v2 (GPLv2)"
       
       - name: Upload license report
         if: always()

--- a/docs/ci/remediation/pass_007_aiohttp_license_governance.md
+++ b/docs/ci/remediation/pass_007_aiohttp_license_governance.md
@@ -1,0 +1,35 @@
+# CI Remediation Pass 007: aiohttp License Governance
+
+## Linked verification
+
+After PR #144 cleared the `regex` composite license expression, the next License Compliance failure surfaced as a single exact expression.
+
+Remaining License Compliance failure:
+
+- Package: aiohttp
+- Version: 3.13.5
+- License expression: Apache-2.0 AND MIT
+
+## Dependency source
+
+- Direct dependency: `aiohttp>=3.8.0`
+- Parent dependency if transitive: none (direct dependency)
+- Project file declaring parent: `requirements.txt`, `pyproject.toml`
+
+## Governance decision
+
+Decision: accept exact composite expression `Apache-2.0 AND MIT`
+
+## Rationale
+
+Both Apache-2.0 and MIT are already accepted by the current policy. The failure is caused by the compliance tool reporting the combined SPDX-style expression as a distinct value. This remediation accepts only the exact composite expression reported by the tool and does not broadly expand license families.
+
+## CI policy action
+
+Add exact allow-list entry:
+
+`Apache-2.0 AND MIT`
+
+## Boundary
+
+No broker code, strategy code, execution behavior, order sizing, live ports, or trading automation changed.


### PR DESCRIPTION
CI Fix 006: aiohttp license governance.

Observed after PR #144 cleared the regex license expression:
- Package: aiohttp
- Version: 3.13.5
- License expression: Apache-2.0 AND MIT
- Failure type: license allow-list gap

Changes:
- Adds governance note pass_007_aiohttp_license_governance.md
- Adds only exact allow-list entry Apache-2.0 AND MIT in security-scan workflow

Boundary:
- No broker code changed
- No strategy code changed
- No execution behavior changed
- No dependency upgrades
- No trading automation changes