### PR TITLE
Allow zc.lockfile license expression

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -255,7 +255,7 @@ jobs:
             --format=json \
             --output-file=licenses.json \
             --fail-on="GPL-2.0;GPL-3.0;AGPL-3.0" \
-            --allow-only="MIT;MIT License;Apache-2.0;Apache Software License;Apache License 2.0;Apache-2.0 OR BSD-2-Clause;MIT OR Apache-2.0;BSD License;Apache Software License; BSD License;BSD;BSD-3-Clause;BSD-2-Clause;ISC;ISC License (ISCL);Python-2.0;Python Software Foundation License;PSF-2.0;MPL-2.0;MPL-2.0 AND (Apache-2.0 OR MIT);MIT AND PSF-2.0;Apache-2.0 AND CNRI-Python;Apache-2.0 AND MIT;UNKNOWN;GNU General Public License v2 (GPLv2)"
+            --allow-only="MIT;MIT License;Apache-2.0;Apache Software License;Apache License 2.0;Apache-2.0 OR BSD-2-Clause;MIT OR Apache-2.0;BSD License;Apache Software License; BSD License;BSD;BSD-3-Clause;BSD-2-Clause;ISC;ISC License (ISCL);Python-2.0;Python Software Foundation License;PSF-2.0;MPL-2.0;MPL-2.0 AND (Apache-2.0 OR MIT);MIT AND PSF-2.0;Apache-2.0 AND CNRI-Python;Apache-2.0 AND MIT;Zope Public License;UNKNOWN;GNU General Public License v2 (GPLv2)"
       
       - name: Upload license report
         if: always()

--- a/docs/ci/remediation/pass_008_zc_lockfile_license_governance.md
+++ b/docs/ci/remediation/pass_008_zc_lockfile_license_governance.md
@@ -1,0 +1,35 @@
+# CI Remediation Pass 008: zc.lockfile License Governance
+
+## Linked verification
+
+After PR #145 cleared the `aiohttp` composite license expression, the next License Compliance failure surfaced as a single exact expression.
+
+Remaining License Compliance failure:
+
+- Package: zc.lockfile
+- Version: 4.0
+- License expression: Zope Public License
+
+## Dependency source
+
+- Direct dependency: none
+- Parent dependency if transitive: `dvc[s3]==3.51.0` (through DVC lock/utility dependency chain)
+- Project file declaring parent: `requirements.txt`, `pyproject.toml`
+
+## Governance decision
+
+Decision: accept exact expression `Zope Public License`
+
+## Rationale
+
+The compliance tool reports `zc.lockfile` under the exact expression `Zope Public License`. This remediation accepts only the exact expression reported by the tool and does not broadly allow unrelated license families or aliases.
+
+## CI policy action
+
+Add exact allow-list entry:
+
+`Zope Public License`
+
+## Boundary
+
+No broker code, strategy code, execution behavior, order sizing, live ports, dependency upgrades, or trading automation changed.


### PR DESCRIPTION
CI Fix 007: zc.lockfile license governance.

Observed after PR #145 cleared the aiohttp license expression:
- Package: zc.lockfile
- Version: 4.0
- License expression: Zope Public License
- Failure type: license allow-list gap

Changes:
- Adds governance note pass_008_zc_lockfile_license_governance.md
- Adds only exact allow-list entry Zope Public License in security-scan workflow

Boundary:
- No broker code changed
- No strategy code changed
- No execution behavior changed
- No dependency upgrades
- No trading automation changes