### PR TITLE
Allow certifi license expression

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -255,7 +255,7 @@ jobs:
             --format=json \
             --output-file=licenses.json \
             --fail-on="GPL-2.0;GPL-3.0;AGPL-3.0" \
-            --allow-only="MIT;MIT License;Apache-2.0;Apache Software License;Apache License 2.0;Apache-2.0 OR BSD-2-Clause;MIT OR Apache-2.0;BSD License;Apache Software License; BSD License;BSD;BSD-3-Clause;BSD-2-Clause;ISC;ISC License (ISCL);Python-2.0;Python Software Foundation License;PSF-2.0;MPL-2.0;MPL-2.0 AND (Apache-2.0 OR MIT);MIT AND PSF-2.0;Apache-2.0 AND CNRI-Python;Apache-2.0 AND MIT;Zope Public License;UNKNOWN;GNU General Public License v2 (GPLv2)"
+            --allow-only="MIT;MIT License;Apache-2.0;Apache Software License;Apache License 2.0;Apache-2.0 OR BSD-2-Clause;MIT OR Apache-2.0;BSD License;Apache Software License; BSD License;BSD;BSD-3-Clause;BSD-2-Clause;ISC;ISC License (ISCL);Python-2.0;Python Software Foundation License;PSF-2.0;MPL-2.0;MPL-2.0 AND (Apache-2.0 OR MIT);MIT AND PSF-2.0;Apache-2.0 AND CNRI-Python;Apache-2.0 AND MIT;Zope Public License;Mozilla Public License 2.0 (MPL 2.0);UNKNOWN;GNU General Public License v2 (GPLv2)"
       
       - name: Upload license report
         if: always()

--- a/docs/ci/remediation/pass_009_certifi_license_governance.md
+++ b/docs/ci/remediation/pass_009_certifi_license_governance.md
@@ -1,0 +1,35 @@
+# CI Remediation Pass 009: certifi License Governance
+
+## Linked verification
+
+After PR #146 cleared the `zc.lockfile` license expression, the next License Compliance failure surfaced as a single exact expression.
+
+Remaining License Compliance failure:
+
+- Package: certifi
+- Version: 2026.4.22
+- License expression: Mozilla Public License 2.0 (MPL 2.0)
+
+## Dependency source
+
+- Direct dependency: none
+- Parent dependency if transitive: `requests==2.33.0` and other HTTP clients in the stack resolve `certifi` transitively
+- Project file declaring parent: `requirements.txt`, `pyproject.toml`
+
+## Governance decision
+
+Decision: accept exact expression `Mozilla Public License 2.0 (MPL 2.0)`
+
+## Rationale
+
+The current allow-list already contains `MPL-2.0`, but the compliance tool reports `certifi` using the expanded expression `Mozilla Public License 2.0 (MPL 2.0)`. This remediation accepts only the exact expression reported by the tool and does not broadly expand unrelated license families.
+
+## CI policy action
+
+Add exact allow-list entry:
+
+`Mozilla Public License 2.0 (MPL 2.0)`
+
+## Boundary
+
+No broker code, strategy code, execution behavior, order sizing, live ports, dependency upgrades, or trading automation changed.


### PR DESCRIPTION
CI Fix 008: certifi license governance.

Observed after PR #146 cleared the zc.lockfile license expression:
- Package: certifi
- Version: 2026.4.22
- License expression: Mozilla Public License 2.0 (MPL 2.0)
- Failure type: license allow-list gap

Changes:
- Adds governance note pass_009_certifi_license_governance.md
- Adds only exact allow-list entry Mozilla Public License 2.0 (MPL 2.0) in security-scan workflow

Boundary:
- No broker code changed
- No strategy code changed
- No execution behavior changed
- No dependency upgrades
- No trading automation changes