### PR TITLE
Document frozendict LGPLv3 governance decision

### DIFF
--- a/docs/ci/remediation/pass_011_frozendict_license_governance.md
+++ b/docs/ci/remediation/pass_011_frozendict_license_governance.md
@@ -1,0 +1,35 @@
+# CI Remediation Pass 011: frozendict License Governance
+
+## Linked verification
+
+After PR #148 cleared the `pygit2` linking-exception license expression, the next License Compliance failure surfaced as a single exact expression.
+
+Remaining License Compliance failure:
+
+- Package: frozendict
+- Version: 2.4.7
+- License expression: GNU Lesser General Public License v3 (LGPLv3)
+
+## Dependency source
+
+- Direct dependency: none
+- Parent dependency if transitive: `yfinance` (requires `frozendict>=2.3.4`)
+- Project file declaring parent: `requirements.txt` (`yfinance>=0.2.38`), `pyproject.toml` (`yfinance>=0.2.40`)
+
+## Governance decision
+
+Decision: defer
+
+## Rationale
+
+`GNU Lesser General Public License v3 (LGPLv3)` is a copyleft-family license expression. It should not be treated like permissive expressions such as MIT, Apache-2.0, BSD, or exact composite permissive values. The project must explicitly decide whether this package is acceptable, whether it is only present through tooling/dev dependencies, or whether the license scan should separate runtime dependencies from CI/dev tooling.
+
+Evidence indicates `frozendict` is pulled through a runtime-declared dependency (`yfinance`) rather than only CI/dev tooling, so this should be reviewed as a runtime licensing decision rather than auto-allowing the token in CI.
+
+## CI policy action
+
+- Defer with governance issue
+
+## Boundary
+
+No broker code, strategy code, execution behavior, order sizing, live ports, dependency upgrades, or trading automation changed.


### PR DESCRIPTION
CI Governance 010: frozendict LGPLv3 decision.

Observed after PR #148 cleared the pygit2 linking-exception expression:
- Package: frozendict
- Version: 2.4.7
- License expression: GNU Lesser General Public License v3 (LGPLv3)
- Failure type: license allow-list gap

Provenance:
- frozendict is transitive through yfinance
- yfinance is directly declared in requirements.txt and pyproject.toml

Governance decision:
- Defer allow-list acceptance
- Do not add LGPLv3 to the license policy yet
- Reason: LGPLv3 is copyleft-family and enters through a runtime-declared dependency path

Changes:
- Adds governance note pass_011_frozendict_license_governance.md
- No workflow allow-list change
- No dependency change

Boundary:
- No broker code changed
- No strategy code changed
- No execution behavior changed
- No dependency upgrades
- No trading automation changes