### PR TITLE
Add dependency lane dry-run validation workflow

### DIFF
--- a/.github/workflows/dependency-lane-dry-run.yml
+++ b/.github/workflows/dependency-lane-dry-run.yml
@@ -1,0 +1,59 @@
+name: Dependency Lane Dry Run
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "requirements-runtime.txt"
+      - "requirements-broker.txt"
+      - "requirements-market-data.txt"
+      - "requirements-mlops.txt"
+      - ".github/workflows/dependency-lane-dry-run.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "requirements-runtime.txt"
+      - "requirements-broker.txt"
+      - "requirements-market-data.txt"
+      - "requirements-mlops.txt"
+      - ".github/workflows/dependency-lane-dry-run.yml"
+
+jobs:
+  validate-lane:
+    name: Validate ${{ matrix.lane }} dependency lane
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: runtime
+            file: requirements-runtime.txt
+          - lane: broker
+            file: requirements-broker.txt
+          - lane: market-data
+            file: requirements-market-data.txt
+          - lane: mlops
+            file: requirements-mlops.txt
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Upgrade packaging tools
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+
+      - name: Install dependency lane
+        run: |
+          python -m pip install --no-input --disable-pip-version-check -r "${{ matrix.file }}"
+
+      - name: Run pip check
+        run: |
+          python -m pip check

--- a/docs/ci/remediation/pass_013_dependency_lane_dry_run_jobs.md
+++ b/docs/ci/remediation/pass_013_dependency_lane_dry_run_jobs.md
@@ -1,0 +1,43 @@
+# Dependency Lane Dry Run Jobs
+
+## Goal
+
+Add CI dry-run validation for dependency lane mirror files without replacing the existing security scan or changing runtime behavior.
+
+## Workflow added
+
+.github/workflows/dependency-lane-dry-run.yml
+
+## Lanes validated
+
+- requirements-runtime.txt
+- requirements-broker.txt
+- requirements-market-data.txt
+- requirements-mlops.txt
+
+## Behavior
+
+Each lane runs in its own GitHub Actions matrix job:
+
+1. Checkout repository
+2. Set up Python 3.13
+3. Upgrade pip/setuptools/wheel
+4. Install the lane requirement file
+5. Run pip check
+
+## Scope
+
+This workflow is additive only.
+
+It does not replace security-scan.yml.
+It does not move dependencies.
+It does not change equirements.txt.
+It does not change pyproject.toml.
+
+## Boundary
+
+No broker code changed.
+No strategy code changed.
+No execution behavior changed.
+No trading automation changed.
+No dependency upgrades were introduced.

--- a/docs/ci/remediation/pass_013_dependency_lane_dry_run_jobs.md
+++ b/docs/ci/remediation/pass_013_dependency_lane_dry_run_jobs.md
@@ -31,7 +31,8 @@ This workflow is additive only.
 
 It does not replace security-scan.yml.
 It does not move dependencies.
-It does not change equirements.txt.
+It does not change 
+equirements.txt.
 It does not change pyproject.toml.
 
 ## Boundary


### PR DESCRIPTION
Adds additive CI dry-run validation for dependency lane mirror files.

What this PR does:
- Adds a new workflow to validate lane mirror files via matrix jobs
- Adds remediation evidence documenting scope and behavior

What this PR does not do:
- Does not replace security-scan.yml
- Does not change requirements.txt
- Does not change pyproject.toml
- Does not move dependencies
- Does not change runtime imports
- Does not touch broker, strategy, execution, or trading code

Outcome:
- CI can validate lane files independently while preserving current install path and security scan behavior.