### PR TITLE
Add dependency lane license dry-run reporting workflow

### DIFF
--- a/.github/workflows/dependency-lane-license-report.yml
+++ b/.github/workflows/dependency-lane-license-report.yml
@@ -1,0 +1,69 @@
+name: Dependency Lane License Report
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "requirements-runtime.txt"
+      - "requirements-broker.txt"
+      - "requirements-market-data.txt"
+      - "requirements-mlops.txt"
+      - ".github/workflows/dependency-lane-license-report.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "requirements-runtime.txt"
+      - "requirements-broker.txt"
+      - "requirements-market-data.txt"
+      - "requirements-mlops.txt"
+      - ".github/workflows/dependency-lane-license-report.yml"
+
+jobs:
+  lane-license-report:
+    name: License report for ${{ matrix.lane }} lane
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: runtime
+            file: requirements-runtime.txt
+          - lane: broker
+            file: requirements-broker.txt
+          - lane: market-data
+            file: requirements-market-data.txt
+          - lane: mlops
+            file: requirements-mlops.txt
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Upgrade packaging tools
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+
+      - name: Install lane dependencies and pip-licenses
+        run: |
+          python -m pip install --no-input --disable-pip-version-check -r "${{ matrix.file }}"
+          python -m pip install --no-input --disable-pip-version-check pip-licenses
+
+      - name: Generate license report JSON
+        run: |
+          New-Item -ItemType Directory "reports/validation/ci/license-lane-reports" -Force | Out-Null
+          python -m piplicenses --format=json --output-file "reports/validation/ci/license-lane-reports/${{ matrix.lane }}-licenses.json"
+        shell: pwsh
+
+      - name: Upload lane license report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-lane-license-report-${{ matrix.lane }}
+          path: reports/validation/ci/license-lane-reports/${{ matrix.lane }}-licenses.json
+          if-no-files-found: error

--- a/docs/ci/remediation/pass_015_dependency_lane_license_reports.md
+++ b/docs/ci/remediation/pass_015_dependency_lane_license_reports.md
@@ -1,0 +1,49 @@
+# Dependency Lane License Dry-Run Reports
+
+## Goal
+
+Generate license reports per dependency lane in CI without enforcing policy yet.
+
+## Workflow added
+
+`dependency-lane-license-report.yml`
+
+## What it does
+
+For each lane mirror file in a matrix job:
+
+1. Set up Python 3.13
+2. Install lane dependencies in isolation
+3. Install `pip-licenses`
+4. Generate a JSON license report
+5. Upload the report as a workflow artifact
+
+## Lanes observed
+
+- requirements-runtime.txt
+- requirements-broker.txt
+- requirements-market-data.txt
+- requirements-mlops.txt
+
+## Output artifacts
+
+- `dependency-lane-license-report-runtime`
+- `dependency-lane-license-report-broker`
+- `dependency-lane-license-report-market-data`
+- `dependency-lane-license-report-mlops`
+
+## Enforcement posture
+
+Observation only.
+
+This workflow does not enforce lane-specific license policy and does not fail builds based on license classification.
+
+## Boundary
+
+No requirements.txt edits.
+No pyproject.toml edits.
+No dependency movement.
+No LGPLv3 allow-list patch.
+No security-scan.yml replacement.
+No runtime behavior changes.
+No trading behavior changes.


### PR DESCRIPTION
Adds additive CI license lane dry-run reporting.

What this change does:
- Adds dependency-lane-license-report.yml matrix workflow
- Installs each dependency lane independently
- Runs pip-licenses and uploads per-lane JSON artifacts
- Adds pass_015 remediation evidence doc

Boundary preserved:
- No requirements.txt edits
- No pyproject.toml edits
- No dependency movement
- No LGPLv3 allow-list patch
- No security-scan.yml replacement
- No runtime behavior changes
- No trading behavior changes

Enforcement posture:
- Observation only
- No lane-specific license gate enforcement in this step