### PR TITLE
Add explicit package license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,13 @@ build-backend = "setuptools.build_meta"
 name = "autotrader"
 version = "0.1.0"
 description = "AutoTrader - Cryptocurrency Trading Bot"
+license = { text = "Proprietary" }
+authors = [
+    { name = "CrisisCore-Systems" }
+]
+maintainers = [
+    { name = "CrisisCore-Systems" }
+]
 requires-python = ">=3.11,<3.14"
 dependencies = [
     "numpy>=2.3.0,<3.0",


### PR DESCRIPTION
Adds explicit package metadata so the internal autotrader package no longer appears as UNKNOWN in lane license reports.

Changes:
- Adds project license metadata: Proprietary
- Adds project author metadata: CrisisCore-Systems
- Adds project maintainer metadata: CrisisCore-Systems

Validation:
- Editable reinstall succeeded
- pip-licenses reports autotrader as Proprietary instead of UNKNOWN

Boundary:
- No dependency movement
- No dependency upgrades
- No requirements.txt changes
- No workflow changes
- No runtime behavior changes
- No broker code changes
- No strategy code changes
- No trading automation changes