### PR TITLE
Document package metadata cleanup validation result

### DIFF
--- a/docs/ci/remediation/pass_017_package_metadata_cleanup_validation.md
+++ b/docs/ci/remediation/pass_017_package_metadata_cleanup_validation.md
@@ -1,0 +1,56 @@
+# Package Metadata Cleanup Validation
+
+## Goal
+
+Validate whether PR #163 caused the internal utotrader package to stop reporting as UNKNOWN in dependency lane license reports.
+
+## Source run
+
+- Workflow: dependency-lane-license-report.yml
+- Run ID: 25987503091
+- Head SHA: e419283b0943fe58bdac10436e2f87c6e41b2505
+- Result: success
+
+## Expected result
+
+utotrader 0.1.0 should report:
+
+Proprietary
+
+## Observed result
+
+| Lane | Package | Version | License |
+|---|---|---:|---|
+| broker | autotrader | 0.1.0 | UNKNOWN |
+| market-data | autotrader | 0.1.0 | UNKNOWN |
+| mlops | autotrader | 0.1.0 | UNKNOWN |
+| runtime | autotrader | 0.1.0 | UNKNOWN |
+
+## Interpretation
+
+The package metadata change in PR #163 was clean and metadata-only, but the dependency lane license report artifacts still show utotrader as UNKNOWN.
+
+This means the CI license-report path does not yet reflect the local editable-install validation result, or the lane report workflow is resolving package metadata differently than the local validation command.
+
+## Next investigation target
+
+Determine why local pip-licenses sees utotrader as Proprietary while CI lane artifacts still report UNKNOWN.
+
+Potential causes to inspect:
+
+1. The lane report workflow may not install the local project package from the checked-out repository.
+2. pip-licenses may be reading a different installed distribution context in CI.
+3. The package metadata format may not be interpreted consistently across local and CI install paths.
+4. The workflow may need an explicit metadata-only install step such as python -m pip install --no-deps -e . before generating lane reports.
+
+## Boundary
+
+No requirements.txt changes.
+No pyproject.toml changes.
+No workflow changes.
+No dependency movement.
+No license allow-list changes.
+No runtime behavior changes.
+No trading behavior changes.
+No artifact JSON files committed.
+No unrelated test files committed.

--- a/docs/ci/remediation/pass_017_package_metadata_cleanup_validation.md
+++ b/docs/ci/remediation/pass_017_package_metadata_cleanup_validation.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Validate whether PR #163 caused the internal utotrader package to stop reporting as UNKNOWN in dependency lane license reports.
+Validate whether PR #163 caused the internal autotrader package to stop reporting as UNKNOWN in dependency lane license reports.
 
 ## Source run
 
@@ -13,7 +13,7 @@ Validate whether PR #163 caused the internal utotrader package to stop reportin
 
 ## Expected result
 
-utotrader 0.1.0 should report:
+autotrader 0.1.0 should report:
 
 Proprietary
 
@@ -28,13 +28,13 @@ Proprietary
 
 ## Interpretation
 
-The package metadata change in PR #163 was clean and metadata-only, but the dependency lane license report artifacts still show utotrader as UNKNOWN.
+The package metadata change in PR #163 was clean and metadata-only, but the dependency lane license report artifacts still show autotrader as UNKNOWN.
 
 This means the CI license-report path does not yet reflect the local editable-install validation result, or the lane report workflow is resolving package metadata differently than the local validation command.
 
 ## Next investigation target
 
-Determine why local pip-licenses sees utotrader as Proprietary while CI lane artifacts still report UNKNOWN.
+Determine why local pip-licenses sees autotrader as Proprietary while CI lane artifacts still report UNKNOWN.
 
 Potential causes to inspect:
 
@@ -54,3 +54,4 @@ No runtime behavior changes.
 No trading behavior changes.
 No artifact JSON files committed.
 No unrelated test files committed.
+


### PR DESCRIPTION
## Summary
- document package metadata cleanup validation after PR #163
- capture successful workflow run with failed proof target
- record that autotrader 0.1.0 still appears as UNKNOWN across broker, market-data, mlops, and runtime lane artifacts

## Scope
- docs-only
- adds docs/ci/remediation/pass_017_package_metadata_cleanup_validation.md

## Boundary
- no requirements changes
- no pyproject changes
- no workflow changes
- no dependency movement
- no runtime/trading behavior changes
- no artifact JSON committed