### PR TITLE
Install local package metadata for lane license reports

### DIFF
--- a/.github/workflows/dependency-lane-license-report.yml
+++ b/.github/workflows/dependency-lane-license-report.yml
@@ -55,6 +55,10 @@ jobs:
           python -m pip install --no-input --disable-pip-version-check -r "${{ matrix.file }}"
           python -m pip install --no-input --disable-pip-version-check pip-licenses
 
+      - name: Install local project metadata
+        run: |
+          python -m pip install --no-deps -e .
+
       - name: Generate license report JSON
         run: |
           New-Item -ItemType Directory "reports/validation/ci/license-lane-reports" -Force | Out-Null

--- a/docs/ci/remediation/pass_019_package_metadata_ci_propagation_fix.md
+++ b/docs/ci/remediation/pass_019_package_metadata_ci_propagation_fix.md
@@ -1,0 +1,39 @@
+# Package Metadata CI Propagation Fix
+
+## Goal
+
+Ensure dependency lane license reports see the checked-out local `autotrader` package metadata before generating `pip-licenses` artifacts.
+
+## Trigger
+
+After PR #163 added explicit package metadata, local validation reported `autotrader` as `Proprietary`, but CI lane artifacts from run `25987503091` still reported `autotrader 0.1.0` as `UNKNOWN`.
+
+## Fix
+
+Add an explicit local project metadata install step to `dependency-lane-license-report.yml`:
+
+`python -m pip install --no-deps -e .`
+
+## Why this is narrow
+
+The step installs the checked-out package metadata without installing dependencies. It does not move dependencies, change manifests, replace security scanning, or alter runtime behavior.
+
+## Expected result
+
+Future lane license artifacts should report:
+
+`autotrader 0.1.0 Proprietary`
+
+instead of:
+
+`autotrader 0.1.0 UNKNOWN`
+
+## Boundary
+
+No requirements.txt changes.
+No pyproject.toml changes.
+No dependency movement.
+No license allow-list changes.
+No security-scan.yml replacement.
+No runtime behavior changes.
+No trading behavior changes.


### PR DESCRIPTION
## Summary
- add explicit local project metadata install step before license report generation in dependency lane workflow
- document fix scope and rationale in pass_019 remediation evidence

## Changes
- .github/workflows/dependency-lane-license-report.yml
- docs/ci/remediation/pass_019_package_metadata_ci_propagation_fix.md

## Why
- PR #163 made package metadata explicit, but CI lane artifacts still reported autotrader as UNKNOWN
- explicit editable metadata install aligns CI context with successful local validation

## Boundary
- no requirements edits
- no pyproject edits
- no dependency movement
- no license policy changes
- no runtime/trading behavior changes