### PR TITLE
Design lane license warning report

### DIFF
--- a/docs/ci/lane_license_warning_report_design.md
+++ b/docs/ci/lane_license_warning_report_design.md
@@ -1,0 +1,51 @@
+# Lane License Warning Report Design
+
+## Purpose
+
+Design a non-blocking CI warning layer for dependency lane license reports.
+
+## Inputs
+
+- runtime lane license report
+- broker lane license report
+- market-data lane license report
+- mlops lane license report
+
+## Output
+
+A readable CI summary showing review-sensitive license findings per lane.
+
+## Warning categories
+
+- UNKNOWN
+- GPL
+- LGPL
+- AGPL
+- MPL
+- Zope
+- CNRI
+- complex AND/OR expressions
+- linking-exception expressions
+
+## Behavior
+
+The warning report must:
+
+- parse lane artifact JSON
+- group findings by lane
+- print a readable summary
+- upload or expose the summary
+- never fail the build
+
+## Non-enforcement statement
+
+This design does not introduce a CI gate.
+
+## Boundary
+
+No requirements.txt changes.
+No pyproject.toml changes.
+No dependency movement.
+No license allow-list changes.
+No runtime behavior changes.
+No trading behavior changes.


### PR DESCRIPTION
## Summary
- adds the non-enforcing lane license warning report design
- defines inputs, warning categories, expected CI summary behavior, and rollout boundary
- keeps this as design only before any workflow implementation

## Scope
- docs-only
- adds docs/ci/lane_license_warning_report_design.md

## Boundary
- no workflow changes
- no requirements changes
- no pyproject changes
- no dependency movement
- no license allow-list changes
- no runtime/trading behavior changes